### PR TITLE
Necessary renaming to match organisation name change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# VitruviusLab - TypeScript
+# VitruviusLabs - TypeScript

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
 	"name": "typescript",
 	"version": "0.1.0",
 	"private": true,
-	"description": "The VitruviusLab mono-repository for TypeScript development.",
+	"description": "The VitruviusLabs mono-repository for TypeScript development.",
 	"author": {
-		"name": "VitruviusLab"
+		"name": "VitruviusLabs"
 	},
 	"contributors": [
 		"Nicolas Cordier-Cerezo <nicolas.cordier@outlook.com>",

--- a/packages/mockingbird/README.md
+++ b/packages/mockingbird/README.md
@@ -11,15 +11,15 @@ It is compatible with the native nodejs test runners.
 Choose your favourite package manager.
 
 ```bash
-pnpm add @vitruvius-lab/mockingbird
+pnpm add @vitruvius-labs/mockingbird
 ```
 
 ```bash
-yarn add @vitruvius-lab/mockingbird
+yarn add @vitruvius-labs/mockingbird
 ```
 
 ```bash
-npm install @vitruvius-lab/mockingbird
+npm install @vitruvius-labs/mockingbird
 ```
 
 ## Documentation

--- a/packages/mockingbird/package.json
+++ b/packages/mockingbird/package.json
@@ -6,12 +6,12 @@
 	"contributors": [
 		"Nicolas Cordier-Cerezo <nicolas.cordier@outlook.com>"
 	],
-	"homepage": "https://github.com/VitruviusLab/typescript/tree/main/packages/mockingbird#readme",
-	"bugs": "https://github.com/VitruviusLab/typescript/issues",
+	"homepage": "https://github.com/VitruviusLabs/typescript/tree/main/packages/mockingbird#readme",
+	"bugs": "https://github.com/VitruviusLabs/typescript/issues",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/VitruviusLab/typescript.git"
+		"url": "https://github.com/VitruviusLabs/typescript.git"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/mockingbird/package.json
+++ b/packages/mockingbird/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@vitruvius-lab/mockingbird",
+	"name": "@vitruvius-labs/mockingbird",
 	"version": "0.1.0",
 	"description": "Module mocking library",
 	"author": "Benjamin Blum <benjamin.blum.98@gmail.com>",
@@ -61,7 +61,7 @@
 		"ci:build": "pnpm build"
 	},
 	"dependencies": {
-		"@vitruvius-lab/ts-predicate": "workspace:*"
+		"@vitruvius-labs/ts-predicate": "workspace:*"
 	},
 	"keywords": [
 		"test",

--- a/packages/mockingbird/src/utils/isMockedDependency.mts
+++ b/packages/mockingbird/src/utils/isMockedDependency.mts
@@ -1,4 +1,4 @@
-import { TypeGuard } from "@vitruvius-lab/ts-predicate";
+import { TypeGuard } from "@vitruvius-labs/ts-predicate";
 
 import type { MockedDependency } from "../Type/MockedDependency.mjs";
 

--- a/packages/mockingbird/src/utils/isMockedModule.mts
+++ b/packages/mockingbird/src/utils/isMockedModule.mts
@@ -1,4 +1,4 @@
-import { TypeGuard } from "@vitruvius-lab/ts-predicate";
+import { TypeGuard } from "@vitruvius-labs/ts-predicate";
 
 function isMockedModule<MockType>(value: unknown, module_identifier: string): asserts value is MockType
 {

--- a/packages/mockingbird/src/utils/isMockingInfos.mts
+++ b/packages/mockingbird/src/utils/isMockingInfos.mts
@@ -1,4 +1,4 @@
-import { TypeAssertion } from "@vitruvius-lab/ts-predicate";
+import { TypeAssertion } from "@vitruvius-labs/ts-predicate";
 
 import type { MockingInfos } from "../Type/MockingInfos.mjs";
 

--- a/packages/ts-predicate/README.md
+++ b/packages/ts-predicate/README.md
@@ -30,15 +30,15 @@ nullish value along with `undefined` and `null`.
 Choose your favourite package manager.
 
 ```bash
-pnpm add @vitruvius-lab/ts-predicate
+pnpm add @vitruvius-labs/ts-predicate
 ```
 
 ```bash
-yarn add @vitruvius-lab/ts-predicate
+yarn add @vitruvius-labs/ts-predicate
 ```
 
 ```bash
-npm install @vitruvius-lab/ts-predicate
+npm install @vitruvius-labs/ts-predicate
 ```
 
 ## Documentation

--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@vitruvius-lab/ts-predicate",
+	"name": "@vitruvius-labs/ts-predicate",
 	"version": "2.4.1",
 	"description": "TypeScript predicates library",
 	"author": "Benjamin Blum <benjamin.blum.98@gmail.com>",

--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -6,12 +6,12 @@
 	"contributors": [
 		"Nicolas Cordier-Cerezo <nicolas.cordier@outlook.com>"
 	],
-	"homepage": "https://github.com/VitruviusLab/typescript/tree/main/packages/ts-predicate#readme",
-	"bugs": "https://github.com/VitruviusLab/typescript/issues",
+	"homepage": "https://github.com/VitruviusLabs/typescript/tree/main/packages/ts-predicate#readme",
+	"bugs": "https://github.com/VitruviusLabs/typescript/issues",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/VitruviusLab/typescript.git"
+		"url": "https://github.com/VitruviusLabs/typescript.git"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
 
   packages/mockingbird:
     dependencies:
-      '@vitruvius-lab/ts-predicate':
+      '@vitruvius-labs/ts-predicate':
         specifier: workspace:*
         version: link:../ts-predicate
 


### PR DESCRIPTION
# Description

The organisation was renamed from VitruviusLab to VitruviusLabs to match a typo made during the declaration of the company with the same name.
This PR aims to unify the naming to VitruviusLabs to avoid unnecessary red tape to change the name of the company.