### PR TITLE
chore: simplify requested path

### DIFF
--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "0.1.11",
+	"version": "0.2.0",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/core/server/rich-client-request.mts
+++ b/packages/architectura/src/core/server/rich-client-request.mts
@@ -9,7 +9,7 @@ import { JSONUtility } from "../../utility/json/json-utility.mjs";
 
 class RichClientRequest extends IncomingMessage
 {
-	private requestedPath: string;
+	private path: string;
 	private pathFragments: Array<string>;
 	private query: ParsedUrlQuery;
 	private rawBody: Buffer;
@@ -21,7 +21,7 @@ class RichClientRequest extends IncomingMessage
 	{
 		super(socket);
 
-		this.requestedPath = "";
+		this.path = "";
 		this.pathFragments = [];
 		this.query = {};
 		this.rawBody = Buffer.alloc(0);
@@ -65,7 +65,7 @@ class RichClientRequest extends IncomingMessage
 			throw new Error("Unexpected error with URL splitting.");
 		}
 
-		this.requestedPath = SPLITTED_URL[0];
+		this.path = SPLITTED_URL[0];
 
 		if (SPLITTED_URL[1] !== undefined)
 		{
@@ -73,7 +73,7 @@ class RichClientRequest extends IncomingMessage
 		}
 
 		const PATH_FRAGMENTS: Array<string> = [];
-		const SPLITTED_REQUESTED_PATH: Array<string> = this.requestedPath.split("/");
+		const SPLITTED_REQUESTED_PATH: Array<string> = this.path.split("/");
 
 		for (const FRAGMENT of SPLITTED_REQUESTED_PATH)
 		{
@@ -189,9 +189,9 @@ class RichClientRequest extends IncomingMessage
 		this.query = query;
 	}
 
-	public getRequestedPath(): string
+	public getPath(): string
 	{
-		return this.requestedPath;
+		return this.path;
 	}
 
 	public getPathFragments(): Array<string>

--- a/packages/architectura/src/core/server/server.mts
+++ b/packages/architectura/src/core/server/server.mts
@@ -214,7 +214,7 @@ class Server
 
 	private static async FindPublicAsset(request: RichClientRequest): Promise<string | undefined>
 	{
-		const REQUEST_PATH: string = request.getRequestedPath();
+		const REQUEST_PATH: string = request.getPath();
 
 		for (const [ROUTE, DIRECTORY] of GlobalConfiguration.GetPublicAssetDirectories())
 		{
@@ -267,7 +267,7 @@ class Server
 	private static FindMatchingEndpoint(request: RichClientRequest): BaseEndpoint | undefined
 	{
 		const REQUEST_METHOD: string | undefined = request.method;
-		const REQUEST_PATH: string = request.getRequestedPath();
+		const REQUEST_PATH: string = request.getPath();
 		const ENDPOINTS: ReadonlyMap<string, BaseEndpoint> = EndpointRegistry.GetEndpoints();
 
 		for (const [, ENDPOINT] of ENDPOINTS)


### PR DESCRIPTION
The class is "RichClient**Request**", adding _requested_ is redundant.

- [x] Update semver
- [x] rename RichClientRequest's requestedPath to path
- [x] rename RichClientRequest's getRequestedPath to getPath