### PR TITLE
feat: endpoint path regexp match

### DIFF
--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/core/endpoint/base.endpoint.mts
+++ b/packages/architectura/src/core/endpoint/base.endpoint.mts
@@ -23,8 +23,14 @@ abstract class BaseEndpoint extends Singleton
 		return this.method;
 	}
 
-	public getRoute(): RegExp | string
+	public getRoute(): RegExp
 	{
+		if (typeof this.route === "string")
+		{
+			// @ts-expect-error: Optimization
+			this.route = new RegExp(this.route);
+		}
+
 		return this.route;
 	}
 

--- a/packages/architectura/src/core/endpoint/base.endpoint.mts
+++ b/packages/architectura/src/core/endpoint/base.endpoint.mts
@@ -8,7 +8,7 @@ import { Singleton } from "../../utility/singleton.mjs";
 abstract class BaseEndpoint extends Singleton
 {
 	protected abstract readonly method: HTTPMethodEnum;
-	protected abstract readonly route: string;
+	protected abstract readonly route: RegExp | string;
 	protected readonly preHooks: Array<BasePreHook> = [];
 	protected readonly excludedGlobalPreHooks: Array<typeof BasePreHook> = [];
 	protected readonly postHooks: Array<BasePostHook> = [];
@@ -23,7 +23,7 @@ abstract class BaseEndpoint extends Singleton
 		return this.method;
 	}
 
-	public getRoute(): string
+	public getRoute(): RegExp | string
 	{
 		return this.route;
 	}

--- a/packages/architectura/src/core/endpoint/endpoint.registry.mts
+++ b/packages/architectura/src/core/endpoint/endpoint.registry.mts
@@ -27,7 +27,7 @@ class EndpointRegistry
 	public static AddEndpoint(endpoint: BaseEndpoint): void
 	{
 		const METHOD: string = endpoint.getMethod();
-		const ROUTE: string = endpoint.getRoute();
+		const ROUTE: string = endpoint.getRoute().toString();
 
 		const IDENTIFIER: string = `${METHOD}::${ROUTE}`;
 

--- a/packages/architectura/src/core/server/rich-client-request.mts
+++ b/packages/architectura/src/core/server/rich-client-request.mts
@@ -10,6 +10,7 @@ import { CookieUtility } from "../utility/cookie.utility.mjs";
 
 class RichClientRequest extends IncomingMessage
 {
+	private readonly pathMatchGroups: Record<string, string> | undefined;
 	private initialized: boolean;
 	private path: string;
 	private pathFragments: Array<string>;
@@ -26,6 +27,7 @@ class RichClientRequest extends IncomingMessage
 		this.initialized = false;
 		this.path = "";
 		this.pathFragments = [];
+		this.pathMatchGroups = undefined;
 		this.query = {};
 		this.rawBody = Promise.resolve(Buffer.alloc(0));
 		this.contentType = "";
@@ -187,6 +189,11 @@ class RichClientRequest extends IncomingMessage
 	public getPathFragments(): Array<string>
 	{
 		return this.pathFragments;
+	}
+
+	public getPathMatchGroups(): Record<string, string> | undefined
+	{
+		return this.pathMatchGroups;
 	}
 
 	public getQuery(): ParsedUrlQuery

--- a/packages/architectura/src/core/server/server.mts
+++ b/packages/architectura/src/core/server/server.mts
@@ -277,25 +277,15 @@ class Server
 				continue;
 			}
 
-			const ROUTE: RegExp | string = ENDPOINT.getRoute();
+			const ROUTE: RegExp = ENDPOINT.getRoute();
 
-			if (typeof ROUTE === "string")
+			const MATCHES: RegExpMatchArray | null = REQUEST_PATH.match(ROUTE);
+
+			if (MATCHES !== null)
 			{
-				if (ROUTE === REQUEST_PATH)
-				{
-					return ENDPOINT;
-				}
-			}
-			else
-			{
-				const MATCHES: RegExpMatchArray | null = REQUEST_PATH.match(ROUTE);
+				Reflect.set(request, "pathMatchGroups", MATCHES.groups);
 
-				if (MATCHES !== null)
-				{
-					Reflect.set(request, "pathMatchGroups", MATCHES.groups);
-
-					return ENDPOINT;
-				}
+				return ENDPOINT;
 			}
 		}
 

--- a/packages/architectura/src/core/server/server.mts
+++ b/packages/architectura/src/core/server/server.mts
@@ -272,9 +272,32 @@ class Server
 
 		for (const [, ENDPOINT] of ENDPOINTS)
 		{
-			if (ENDPOINT.getMethod() === REQUEST_METHOD && new RegExp(ENDPOINT.getRoute()).test(REQUEST_PATH))
+			if (ENDPOINT.getMethod() !== REQUEST_METHOD)
 			{
-				return ENDPOINT;
+				continue;
+			}
+
+			const ROUTE: RegExp | string = ENDPOINT.getRoute();
+
+			if (typeof ROUTE === "string")
+			{
+				if (ROUTE === REQUEST_PATH)
+				{
+					return ENDPOINT;
+				}
+			}
+			else
+			{
+				const REGEXP: RegExp = new RegExp(ROUTE);
+
+				const MATCHES: RegExpExecArray | null = REGEXP.exec(REQUEST_PATH);
+
+				if (MATCHES !== null)
+				{
+					Reflect.set(request, "pathMatchGroups", MATCHES.groups);
+
+					return ENDPOINT;
+				}
 			}
 		}
 

--- a/packages/architectura/src/core/server/server.mts
+++ b/packages/architectura/src/core/server/server.mts
@@ -288,9 +288,7 @@ class Server
 			}
 			else
 			{
-				const REGEXP: RegExp = new RegExp(ROUTE);
-
-				const MATCHES: RegExpExecArray | null = REGEXP.exec(REQUEST_PATH);
+				const MATCHES: RegExpMatchArray | null = REQUEST_PATH.match(ROUTE);
 
 				if (MATCHES !== null)
 				{


### PR DESCRIPTION
- [x] Update semver
- [x] Allow `BaseEndpoint.route` to be a `RegExp`
- [x] Add `RichClientRequest.getPathMatchGroups()` that return match groups