### PR TITLE
Fix posts requests

### DIFF
--- a/packages/aws-signature-v4/mocks/definitions/interfaces/signature-instantiation.interface.mts
+++ b/packages/aws-signature-v4/mocks/definitions/interfaces/signature-instantiation.interface.mts
@@ -6,9 +6,9 @@ function mockSignatureInstantiationInterface(): SignatureInstantiationInterface
 	const mocked_access_secret: string = "mocked_access_secret";
 	const mocked_region: string = "mocked_region";
 	const mocked_service: string = "s3";
-	const mocked_url: string = "https://www.lilo.org/";
+	const mocked_url: string = "https://www.example.com/";
 	const mocked_method: HTTPMethodEnum = HTTPMethodEnum.POST;
-	const mocked_host: string = "www.lilo.org";
+	const mocked_host: string = "www.example.com";
 	const mocked_body: string = JSON.stringify({ foo: "bar" });
 	const mocked_headers: Headers = new Headers({
 		Host: mocked_host,

--- a/packages/aws-signature-v4/package.json
+++ b/packages/aws-signature-v4/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/aws-signature-v4",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "A simple library to generate AWS Signature V4",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/aws-signature-v4/src/signature.mts
+++ b/packages/aws-signature-v4/src/signature.mts
@@ -280,6 +280,11 @@ class Signature
 
 	private generateCanonicalQueryString(): void
 	{
+		if (this.method !== HTTPMethodEnum.GET && this.method !== HTTPMethodEnum.HEAD)
+		{
+			return;
+		}
+
 		this.url.searchParams.sort();
 
 		this.canonicalQueryString = this.url.searchParams.toString();

--- a/packages/aws-signature-v4/test/signature.spec.mts
+++ b/packages/aws-signature-v4/test/signature.spec.mts
@@ -855,6 +855,25 @@ describe("Signature", (): void => {
 		it("should compute the canonicalQueryString property when called", (): void => {
 			const mocked_instantiation_interface: SignatureInstantiationInterface = {
 				...mockSignatureInstantiationInterface(),
+				method: HTTPMethodEnum.POST,
+				url: "https://www.lilo.org?foo=bar&quz=qux&a=b",
+			};
+
+			const expected_canonical_query_string: string = "";
+
+			const signature: Signature = new Signature(mocked_instantiation_interface);
+
+			// @ts-expect-error - We need to call this private method for testing purposes.
+			signature.generateCanonicalQueryString();
+
+			// @ts-expect-error - We need to access this private property for testing purposes.
+			expect(signature.canonicalQueryString).to.deep.equal(expected_canonical_query_string, "Signature canonicalQueryString is not equal to the expected value after generateCanonicalQueryString has been called.");
+		});
+
+		it("should immediately return when the method is not GET or HEAD", (): void => {
+			const mocked_instantiation_interface: SignatureInstantiationInterface = {
+				...mockSignatureInstantiationInterface(),
+				method: HTTPMethodEnum.GET,
 				url: "https://www.lilo.org?foo=bar&quz=qux&a=b",
 			};
 

--- a/packages/aws-signature-v4/test/signature.spec.mts
+++ b/packages/aws-signature-v4/test/signature.spec.mts
@@ -852,7 +852,7 @@ describe("Signature", (): void => {
 	});
 
 	describe("generateCanonicalQueryString", (): void => {
-		it("should compute the canonicalQueryString property when called", (): void => {
+		it("should immediately return when the method is not GET or HEAD", (): void => {
 			const mocked_instantiation_interface: SignatureInstantiationInterface = {
 				...mockSignatureInstantiationInterface(),
 				method: HTTPMethodEnum.POST,
@@ -870,7 +870,7 @@ describe("Signature", (): void => {
 			expect(signature.canonicalQueryString).to.deep.equal(expected_canonical_query_string, "Signature canonicalQueryString is not equal to the expected value after generateCanonicalQueryString has been called.");
 		});
 
-		it("should immediately return when the method is not GET or HEAD", (): void => {
+		it("should compute the canonicalQueryString property when called", (): void => {
 			const mocked_instantiation_interface: SignatureInstantiationInterface = {
 				...mockSignatureInstantiationInterface(),
 				method: HTTPMethodEnum.GET,


### PR DESCRIPTION
# Description

`POST` requests (and any request that can have a body) are currently not handled properly and will result in a failed signature.
This is because the `canonicalQueryString` property is not being handled properly.