### PR TITLE
Dev/zamralik/architectura/bugfix send response when unhandled by error hooks

### DIFF
--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "0.4.4",
+	"version": "0.4.5",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/core/server/server.mts
+++ b/packages/architectura/src/core/server/server.mts
@@ -184,7 +184,7 @@ class Server
 
 		const CONTENT_TYPE: string = ContentType.Get(extname(FILE_PATH));
 
-		context.getResponse().replyWith({
+		await context.getResponse().replyWith({
 			payload: FILE,
 			contentType: CONTENT_TYPE,
 		});
@@ -347,6 +347,14 @@ class Server
 		if (!RESPONSE.areHeadersSent())
 		{
 			LoggerProxy.Error(is_error ? "Unhandled server error." : "Unhandled response.");
+
+			RESPONSE.getHeaderNames().forEach(
+				(header: string): void =>
+				{
+					RESPONSE.removeHeader(header);
+				}
+			);
+
 			RESPONSE.writeHead(HTTPStatusCodeEnum.INTERNAL_SERVER_ERROR);
 			RESPONSE.write("500 - Internal Server Error.");
 			RESPONSE.end();

--- a/packages/architectura/src/endpoint/hello-world.endpoint.mts
+++ b/packages/architectura/src/endpoint/hello-world.endpoint.mts
@@ -7,9 +7,9 @@ class HelloWorldEndpoint extends BaseEndpoint
 	protected readonly method: HTTPMethodEnum = HTTPMethodEnum.GET;
 	protected readonly route: string = "^.*$";
 
-	public override execute(context: ExecutionContext): void
+	public override async execute(context: ExecutionContext): Promise<void>
 	{
-		context.getResponse().text("Hello World!");
+		await context.getResponse().text("Hello World!");
 	}
 }
 


### PR DESCRIPTION
- [x] Update semver
- [x] Add internal method `FinalizeResponse` that will handle unsent responses
- [x] Response sending is now asynchronous
- [x] Error while encoding payload will be caught