### PR TITLE
bugfix: repository custom getters need metadata

### DIFF
--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/ddd/base.factory.mts
+++ b/packages/architectura/src/ddd/base.factory.mts
@@ -1,5 +1,4 @@
 import type { BaseModelInstantiationInterface } from "./definition/interface/base-model-instantiation.interface.mjs";
-
 import type { BaseModel } from "./base.model.mjs";
 
 abstract class BaseFactory<
@@ -17,9 +16,7 @@ abstract class BaseFactory<
 
 	public create(parameters: I): T
 	{
-		const model: T = new this.ClassConstructor(parameters);
-
-		return model;
+		return new this.ClassConstructor(parameters);
 	}
 }
 

--- a/packages/architectura/src/ddd/base.repository.mts
+++ b/packages/architectura/src/ddd/base.repository.mts
@@ -9,7 +9,7 @@ abstract class BaseRepository<
 	C extends new (arg: I) => T
 >
 {
-	protected readonly factory: BaseFactory<T, I, C>;
+	private readonly factory: BaseFactory<T, I, C>;
 
 	public constructor(factory: BaseFactory<T, I, C>)
 	{
@@ -47,9 +47,7 @@ abstract class BaseRepository<
 			return undefined;
 		}
 
-		const model: T = this.factory.create(data);
-
-		BaseRepository.SetImmutableFields(model, data);
+		const model: T = this.create(data);
 
 		return model;
 	}
@@ -75,9 +73,7 @@ abstract class BaseRepository<
 			return undefined;
 		}
 
-		const model: T = this.factory.create(data);
-
-		BaseRepository.SetImmutableFields(model, data);
+		const model: T = this.create(data);
 
 		return model;
 	}
@@ -98,17 +94,16 @@ abstract class BaseRepository<
 	{
 		if (model.hasId())
 		{
-			// eslint-disable-next-line @typescript-eslint/no-shadow -- Harmless shadowing
-			const metadata: ModelMetadataInterface = await this.update(model);
+			const update_metadata: ModelMetadataInterface = await this.update(model);
 
-			BaseRepository.SetImmutableFields(model, metadata);
+			BaseRepository.SetImmutableFields(model, update_metadata);
 
 			return;
 		}
 
-		const metadata: ModelMetadataInterface = await this.register(model);
+		const register_metadata: ModelMetadataInterface = await this.register(model);
 
-		BaseRepository.SetImmutableFields(model, metadata);
+		BaseRepository.SetImmutableFields(model, register_metadata);
 	}
 
 	public async delete(model: T): Promise<void>
@@ -116,6 +111,15 @@ abstract class BaseRepository<
 		await this.destroy(model.getId());
 
 		BaseRepository.ClearImmutableFields(model);
+	}
+
+	protected create(parameters: I & ModelMetadataInterface): T
+	{
+		const model: T = this.factory.create(parameters);
+
+		BaseRepository.SetImmutableFields(model, parameters);
+
+		return model;
 	}
 }
 

--- a/packages/architectura/src/ddd/definition/interface/model-metadata.interface.mts
+++ b/packages/architectura/src/ddd/definition/interface/model-metadata.interface.mts
@@ -1,10 +1,11 @@
 interface ModelMetadataInterface
 {
 	id: bigint | number | string;
-	uuid: string;
 	createdAt: Date;
 	updatedAt: Date;
 	deletedAt: Date | undefined;
+	// UUID is only added to make it mandatory when combined with BaseModelInstantiationInterface
+	uuid: string;
 }
 
 export type { ModelMetadataInterface };


### PR DESCRIPTION
- [x] Updated semver
- [x] New method `BaseRepository.create()` to instantiate models from custom getters data
- [x] Make `BaseRepository.factory` private
- [x] Added comment to explain why `ModelMetadataInterface` has a property `uuid`