### PR TITLE
feat: support other encodings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -360,7 +360,6 @@
 		"@typescript-eslint/no-unsafe-assignment": "error",
 		"@typescript-eslint/no-unsafe-call": "error",
 		"@typescript-eslint/no-unsafe-declaration-merging": "error",
-		"@typescript-eslint/no-unsafe-enum-comparison": "error",
 		"@typescript-eslint/no-unsafe-member-access": "error",
 		"@typescript-eslint/no-unsafe-return": "error",
 		"@typescript-eslint/no-unsafe-unary-minus": "error",
@@ -572,12 +571,6 @@
 			"error",
 			{
 				"max": 30
-			}
-		],
-		"consistent-return": [
-			"error",
-			{
-				"treatUndefinedAsUnspecified": false
 			}
 		],
 		"default-case-last": "error",

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -20,7 +20,8 @@
 		"Zamralik",
 		"vars",
 		"sonarjs",
-		"traefik"
+		"traefik",
+		"brotli"
 	],
 	"flagWords": [
 		"hte"

--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "0.4.6",
+	"version": "0.5.0",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/core/server/definition/enum/_index.mts
+++ b/packages/architectura/src/core/server/definition/enum/_index.mts
@@ -1,3 +1,4 @@
+export * from "./content-encoding.enum.mjs";
 export * from "./content-type.enum.mjs";
 export * from "./cookie-same-site.enum.mjs";
 export * from "./http-status-code.enum.mjs";

--- a/packages/architectura/src/core/server/definition/enum/content-encoding.enum.mts
+++ b/packages/architectura/src/core/server/definition/enum/content-encoding.enum.mts
@@ -1,0 +1,8 @@
+const enum ContentEncodingEnum
+{
+	GZIP = "gzip",
+	BROTLI = "br",
+	DEFLATE = "deflate",
+}
+
+export { ContentEncodingEnum };

--- a/packages/architectura/src/core/server/server.mts
+++ b/packages/architectura/src/core/server/server.mts
@@ -373,7 +373,6 @@ class Server
 	{
 		TypeAssertion.isInteger(port);
 
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison -- Range boundaries
 		if (port < PortsEnum.LOWEST_AVAILABLE || PortsEnum.HIGHEST_AVAILABLE < port)
 		{
 			throw new Error(`"port" parameter isn't within range of valid ports. It must be an integer between ${PortsEnum.LOWEST_AVAILABLE.toString()} and ${PortsEnum.HIGHEST_AVAILABLE.toString()}`);

--- a/packages/architectura/src/service/jwt/predicate/assert-token.mts
+++ b/packages/architectura/src/service/jwt/predicate/assert-token.mts
@@ -3,7 +3,6 @@ import type { TokenType } from "../definition/type/token.type.mjs";
 
 function assertToken(parts: Array<string>): asserts parts is TokenType
 {
-	// eslint-disable-next-line @typescript-eslint/no-unsafe-enum-comparison
 	if (parts.length !== JWTConstantEnum.TOKEN_PARTS)
 	{
 		throw new Error("There is an error with the validating RegExp.");


### PR DESCRIPTION
- [x] Updated semver
- [x] Added support for encodings Gzip, Brotli, Deflate
- [x] Pick encoding from request `accept-encoding` header.
- [x] Added `brotli` to cspell ignored words.
- [x] Disabled eslint rule `consistent-return` as it conflicts with exhaustive switch and TS ensure all code paths have a return when the return type is not void.
- [x] Disabled eslint rule `@typescript-eslint/no-unsafe-enum-comparison` as it conflicts with variable & enum comparison. `@typescript-eslint/no-unnecessary-condition` already prevent constant conditions.