### PR TITLE
chore: nullable type improvements

### DIFF
--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/core/_index.mts
+++ b/packages/architectura/src/core/_index.mts
@@ -2,5 +2,6 @@ export * from "./definition/_index.mjs";
 export * from "./endpoint/_index.mjs";
 export * from "./execution-context/_index.mjs";
 export * from "./hook/_index.mjs";
+export * from "./predicate/_index.mjs";
 export * from "./server/_index.mjs";
 export * from "./utility/_index.mjs";

--- a/packages/architectura/src/core/execution-context/execution-context.mts
+++ b/packages/architectura/src/core/execution-context/execution-context.mts
@@ -1,14 +1,12 @@
 import type { ExecutionContextInstantiationInterface } from "./definition/interface/execution-context-instantiation.interface.mjs";
 import type { RichClientRequest } from "../server/rich-client-request.mjs";
 import type { RichServerResponse } from "../server/rich-server-response.mjs";
-import type { Session } from "../../service/session/entity/session.model.mjs";
 import { ContextualStorage } from "../utility/contextual-storage.mjs";
 
 class ExecutionContext extends ContextualStorage
 {
-	private readonly request: RichClientRequest;
-	private readonly response: RichServerResponse;
-	private session: Session | undefined;
+	public readonly request: RichClientRequest;
+	public readonly response: RichServerResponse;
 
 	public constructor(context_items: ExecutionContextInstantiationInterface)
 	{
@@ -16,7 +14,6 @@ class ExecutionContext extends ContextualStorage
 
 		this.request = context_items.request;
 		this.response = context_items.response;
-		this.session = undefined;
 	}
 
 	public getRequest(): RichClientRequest
@@ -27,16 +24,6 @@ class ExecutionContext extends ContextualStorage
 	public getResponse(): RichServerResponse
 	{
 		return this.response;
-	}
-
-	public getSession(): Session | undefined
-	{
-		return this.session;
-	}
-
-	public setSession(session: Session): void
-	{
-		this.session = session;
 	}
 }
 

--- a/packages/architectura/src/core/predicate/_index.mts
+++ b/packages/architectura/src/core/predicate/_index.mts
@@ -1,0 +1,1 @@
+export * from "./is-http-method-enum.mjs";

--- a/packages/architectura/src/core/predicate/is-http-method-enum.mts
+++ b/packages/architectura/src/core/predicate/is-http-method-enum.mts
@@ -1,0 +1,19 @@
+import { isEnumValue } from "@vitruvius-labs/ts-predicate/type-guard";
+import { HTTPMethodEnum } from "../_index.mjs";
+
+function isHTTPMethodEnum(value: unknown): value is HTTPMethodEnum
+{
+	return isEnumValue(value, [
+		HTTPMethodEnum.GET,
+		HTTPMethodEnum.HEAD,
+		HTTPMethodEnum.POST,
+		HTTPMethodEnum.PUT,
+		HTTPMethodEnum.DELETE,
+		HTTPMethodEnum.CONNECT,
+		HTTPMethodEnum.OPTIONS,
+		HTTPMethodEnum.TRACE,
+		HTTPMethodEnum.PATCH,
+	]);
+}
+
+export { isHTTPMethodEnum };

--- a/packages/architectura/src/core/server/rich-server-response.mts
+++ b/packages/architectura/src/core/server/rich-server-response.mts
@@ -99,14 +99,39 @@ class RichServerResponse extends HTTPServerResponse<RichClientRequest>
 		return this.writableFinished;
 	}
 
-	public getContent(): string | undefined
+	public hasContent(): boolean
+	{
+		return this.content !== undefined;
+	}
+
+	public getUnsafeContent(): Buffer | string | undefined
+	{
+		return this.content;
+	}
+
+	public getRawContent(): Buffer
+	{
+		if (this.content instanceof Buffer)
+		{
+			return this.content;
+		}
+
+		if (this.content === undefined)
+		{
+			return Buffer.alloc(0);
+		}
+
+		return Buffer.from(this.content);
+	}
+
+	public getContent(): string
 	{
 		if (this.content instanceof Buffer)
 		{
 			return this.content.toString();
 		}
 
-		return this.content;
+		return this.content ?? "";
 	}
 
 	public setContent(content: Buffer | string): void

--- a/packages/architectura/src/ddd/base.model.mts
+++ b/packages/architectura/src/ddd/base.model.mts
@@ -38,18 +38,33 @@ abstract class BaseModel
 		return this.uuid;
 	}
 
-	public getCreatedAt(): Date | undefined
+	public getCreatedAt(): Date
 	{
+		if (this.createdAt === undefined)
+		{
+			throw new Error("You must save this entity for it to have a creation date.");
+		}
+
 		return this.createdAt;
 	}
 
-	public getUpdatedAt(): Date | undefined
+	public getUpdatedAt(): Date
 	{
+		if (this.updatedAt === undefined)
+		{
+			throw new Error("You must save this entity for it to have an update date.");
+		}
+
 		return this.updatedAt;
 	}
 
 	public getDeletedAt(): Date | undefined
 	{
+		if (this.id === undefined)
+		{
+			throw new Error("You must save this entity for it to maybe have a deletion date.");
+		}
+
 		return this.deletedAt;
 	}
 }

--- a/packages/architectura/src/ddd/base.repository.mts
+++ b/packages/architectura/src/ddd/base.repository.mts
@@ -21,7 +21,7 @@ abstract class BaseRepository<
 		Reflect.set(model, "id", BigInt(data.id));
 		Reflect.set(model, "createdAt", data.createdAt);
 		Reflect.set(model, "updatedAt", data.updatedAt);
-		Reflect.set(model, "deletedAt", data.deletedAt);
+		Reflect.set(model, "deletedAt", data.deletedAt ?? undefined);
 	}
 
 	private static ClearImmutableFields(model: BaseModel): void

--- a/packages/architectura/src/ddd/definition/interface/model-metadata.interface.mts
+++ b/packages/architectura/src/ddd/definition/interface/model-metadata.interface.mts
@@ -3,7 +3,7 @@ interface ModelMetadataInterface
 	id: bigint | number | string;
 	createdAt: Date;
 	updatedAt: Date;
-	deletedAt: Date | undefined;
+	deletedAt: Date | null | undefined;
 	// UUID is only added to make it mandatory when combined with BaseModelInstantiationInterface
 	uuid: string;
 }

--- a/packages/architectura/src/service/session/hook/session.pre-hook.mts
+++ b/packages/architectura/src/service/session/hook/session.pre-hook.mts
@@ -60,7 +60,7 @@ class SessionPreHook extends BasePreHook
 		if (session !== undefined)
 		{
 			session.refresh();
-			context.setSession(session);
+			context.setContextualItem(Session, session);
 
 			return;
 		}
@@ -68,7 +68,7 @@ class SessionPreHook extends BasePreHook
 		session = new Session(SESSION_ID ?? randomUUID(), this.delegate);
 
 		SessionRegistry.AddSession(session);
-		context.setSession(session);
+		context.setContextualItem(Session, session);
 
 		if (SESSION_ID === undefined)
 		{


### PR DESCRIPTION
- [x] Update semver
- [x] DDD
  - [x] `ModelMetadataInterface` now accept a `null` value for `deletedAt`
- [x] `ExecutionContext` now uses the `ContextualStorage` for the `Session`
- [x] New type guard `isHTTPMethodEnum`
- [x] `RichClientRequest`
  - [x] `getUnsafeMethod` returns either a string or undefined
  - [x] `hasStandardMethod` returns wether the request has a method and it's a standard one
  - [x] `getMethod` returns the method if it exists and is standard, or throws otherwise
  - [x] `getUnsafeURL` returns either a string or undefined
  - [x] `hasURL` returns whether there is a URL or not for this request
  - [x] `getURL` returns the URL or throws if there is none
  - [x] `getPathMatchGroups` now returns an empty record if there is no match groups.
- [x] `RichServerResponse`
  - [x]  `hasContent` returns whether there is content or not (content can be empty!)
  - [x]  `getUnsafeContent` returns either a `Buffer`, a `string`, or `undefined`
  - [x] `getRawContent` returns a `Buffer`, if there is no content it will be an empty buffer
  - [x] `getContent` now return a `string`, if there is no content it will be an empty string