### PR TITLE
Fix canonical query string generation

### DIFF
--- a/packages/aws-signature-v4/package.json
+++ b/packages/aws-signature-v4/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/aws-signature-v4",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "A simple library to generate AWS Signature V4",
 	"author": {
 		"name": "VitruviusLabs"
@@ -53,6 +53,5 @@
 		"ci:publish:dry": "pnpm publish --access public --dry-run --no-git-checks",
 		"ci:build": "pnpm build"
 	},
-	"keywords": [
-	]
+	"keywords": []
 }

--- a/packages/aws-signature-v4/src/signature.mts
+++ b/packages/aws-signature-v4/src/signature.mts
@@ -280,11 +280,6 @@ class Signature
 
 	private generateCanonicalQueryString(): void
 	{
-		if (this.method !== HTTPMethodEnum.GET && this.method !== HTTPMethodEnum.HEAD)
-		{
-			return;
-		}
-
 		this.url.searchParams.sort();
 
 		this.canonicalQueryString = this.url.searchParams.toString();

--- a/packages/aws-signature-v4/test/signature.spec.mts
+++ b/packages/aws-signature-v4/test/signature.spec.mts
@@ -852,24 +852,6 @@ describe("Signature", (): void => {
 	});
 
 	describe("generateCanonicalQueryString", (): void => {
-		it("should immediately return when the method is not GET or HEAD", (): void => {
-			const mocked_instantiation_interface: SignatureInstantiationInterface = {
-				...mockSignatureInstantiationInterface(),
-				method: HTTPMethodEnum.POST,
-				url: "https://www.lilo.org?foo=bar&quz=qux&a=b",
-			};
-
-			const expected_canonical_query_string: string = "";
-
-			const signature: Signature = new Signature(mocked_instantiation_interface);
-
-			// @ts-expect-error - We need to call this private method for testing purposes.
-			signature.generateCanonicalQueryString();
-
-			// @ts-expect-error - We need to access this private property for testing purposes.
-			expect(signature.canonicalQueryString).to.deep.equal(expected_canonical_query_string, "Signature canonicalQueryString is not equal to the expected value after generateCanonicalQueryString has been called.");
-		});
-
 		it("should compute the canonicalQueryString property when called", (): void => {
 			const mocked_instantiation_interface: SignatureInstantiationInterface = {
 				...mockSignatureInstantiationInterface(),


### PR DESCRIPTION
# Description

An exception was made for canonical query string generation but this has proven to be unnecessary and to create bugs.
This PR aims to address this issue by removing the exception.