### PR TITLE
fix: union typing issues and renamed wrapTest to unary

### DIFF
--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/ts-predicate",
-	"version": "5.0.0",
+	"version": "5.0.1",
 	"description": "TypeScript predicates library",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/ts-predicate/src/type-assertion/assert-union.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-union.mts
@@ -7,6 +7,7 @@ function assertUnion<T1, T2>(value: unknown, tests: [Test<T1>, Test<T2>]): asser
 function assertUnion<T1, T2, T3>(value: unknown, tests: [Test<T1>, Test<T2>, Test<T3>]): asserts value is T1 | T2 | T3;
 function assertUnion<T1, T2, T3, T4>(value: unknown, tests: [Test<T1>, Test<T2>, Test<T3>, Test<T4>]): asserts value is T1 | T2 | T3 | T4;
 function assertUnion<T1, T2, T3, T4, T5>(value: unknown, tests: [Test<T1>, Test<T2>, Test<T3>, Test<T4>, Test<T5>]): asserts value is T1 | T2 | T3 | T4 | T5;
+function assertUnion<T>(value: unknown, tests: Array<Test<T>>): asserts value is T;
 
 function assertUnion(value: unknown, tests: Array<Test<unknown>>): asserts value is unknown
 {

--- a/packages/ts-predicate/src/type-assertion/utils/item-assertion.mts
+++ b/packages/ts-predicate/src/type-assertion/utils/item-assertion.mts
@@ -1,6 +1,7 @@
 import type { Test } from "../../definition/_index.mjs";
 import { ValidationError } from "./validation-error.mjs";
 
+/** @internal */
 function itemAssertion<Type>(value: unknown, callable: Test<Type>): asserts value is Type
 {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- assertion return undefined

--- a/packages/ts-predicate/src/type-assertion/utils/validate-property.mts
+++ b/packages/ts-predicate/src/type-assertion/utils/validate-property.mts
@@ -5,6 +5,7 @@ import { itemAssertion } from "./item-assertion.mjs";
 import { ValidationError } from "./validation-error.mjs";
 import { rethrowUnexpectedError } from "../../utils/rethrow-unexpected-error.mjs";
 
+/** @internal */
 function validateProperty(value: object, key: string, property_descriptor: StructuredDataPropertyDescriptor<unknown>): void
 {
 	if (property_descriptor.ignore ?? false)

--- a/packages/ts-predicate/src/type-guard/is-union.mts
+++ b/packages/ts-predicate/src/type-guard/is-union.mts
@@ -5,6 +5,7 @@ function isUnion<T1, T2>(value: unknown, tests: [Test<T1>, Test<T2>]): value is 
 function isUnion<T1, T2, T3>(value: unknown, tests: [Test<T1>, Test<T2>, Test<T3>]): value is T1 | T2 | T3;
 function isUnion<T1, T2, T3, T4>(value: unknown, tests: [Test<T1>, Test<T2>, Test<T3>, Test<T4>]): value is T1 | T2 | T3 | T4;
 function isUnion<T1, T2, T3, T4, T5>(value: unknown, tests: [Test<T1>, Test<T2>, Test<T3>, Test<T4>, Test<T5>]): value is T1 | T2 | T3 | T4 | T5;
+function isUnion<T>(value: unknown, tests: Array<Test<T>>): value is T;
 
 function isUnion(value: unknown, tests: Array<Test<unknown>>): value is unknown
 {

--- a/packages/ts-predicate/src/type-guard/utils/item-guard.mts
+++ b/packages/ts-predicate/src/type-guard/utils/item-guard.mts
@@ -1,6 +1,7 @@
 import type { Test } from "../../definition/_index.mjs";
 import { rethrowUnexpectedError } from "../../utils/rethrow-unexpected-error.mjs";
 
+/** @internal */
 function itemGuard<Type>(value: unknown, callable: Test<Type>): value is Type
 {
 	try

--- a/packages/ts-predicate/src/utils/build-array-constraints.mts
+++ b/packages/ts-predicate/src/utils/build-array-constraints.mts
@@ -1,6 +1,7 @@
 import type { ArrayConstraints } from "../definition/interface/array-constraints.mjs";
 import type { Test } from "../definition/type/test.mjs";
 
+/** @internal */
 function buildArrayConstraints<Type>(constraints: ArrayConstraints<Type> | Test<Type> | undefined): ArrayConstraints<Type> | undefined
 {
 	if (typeof constraints === "function")

--- a/packages/ts-predicate/src/utils/build-record-constraints.mts
+++ b/packages/ts-predicate/src/utils/build-record-constraints.mts
@@ -1,6 +1,7 @@
 import type { RecordConstraints } from "../definition/interface/record-constraints.mjs";
 import type { Test } from "../definition/type/test.mjs";
 
+/** @internal */
 function buildRecordConstraints<Type>(constraints: RecordConstraints<Type> | Test<Type> | undefined): RecordConstraints<Type> | undefined
 {
 	if (typeof constraints === "function")

--- a/packages/ts-predicate/src/utils/build-structured-data-options.mts
+++ b/packages/ts-predicate/src/utils/build-structured-data-options.mts
@@ -1,5 +1,6 @@
 import type { StructuredDataOptions } from "../definition/interface/structured-data-options.mjs";
 
+/** @internal */
 function buildStructuredDataOptions(options?: StructuredDataOptions | undefined): Required<StructuredDataOptions>
 {
 	return {

--- a/packages/ts-predicate/src/utils/get-structured-data-property-descriptor.mts
+++ b/packages/ts-predicate/src/utils/get-structured-data-property-descriptor.mts
@@ -2,6 +2,7 @@ import type { Test } from "../definition/type/test.mjs";
 import type { StructuredDataDescriptor } from "../definition/interface/structured-data-descriptor.mjs";
 import type { StructuredDataPropertyDescriptor } from "../definition/type/structured-data-property-descriptor.mjs";
 
+/** @internal */
 function getStructuredDataPropertyDescriptor<Type>(descriptor: StructuredDataDescriptor<Type> | Test<NonNullable<Type>>, key: string): StructuredDataPropertyDescriptor<unknown>
 {
 	// @ts-expect-error: Key mapping

--- a/packages/ts-predicate/src/utils/rethrow-unexpected-error.mts
+++ b/packages/ts-predicate/src/utils/rethrow-unexpected-error.mts
@@ -1,6 +1,7 @@
 import { ValidationError } from "../type-assertion/utils/validation-error.mjs";
 import { toError } from "../helper/to-error.mjs";
 
+/** @internal */
 function rethrowUnexpectedError(error: unknown): asserts error is ValidationError
 {
 	if (!(error instanceof ValidationError))


### PR DESCRIPTION
- [x] Updated semver
- [x] Fix issue with `isUnion` and `assertUnion` typing
- [x] Renamed `wrapTest` to `unary`
- [x] Added some TS doc comment `@internal` when appropriate