### PR TITLE
fix: response state flags not updated by node

### DIFF
--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/_index.mts
+++ b/packages/architectura/src/_index.mts
@@ -2,5 +2,6 @@ export * from "./core/_index.mjs";
 export * from "./ddd/_index.mjs";
 export * from "./definition/_index.mjs";
 export * from "./endpoint/_index.mjs";
+export * from "./predicate/_index.mjs";
 export * from "./service/_index.mjs";
 export * from "./utility/_index.mjs";

--- a/packages/architectura/src/core/server/server.mts
+++ b/packages/architectura/src/core/server/server.mts
@@ -362,7 +362,7 @@ class Server
 			return;
 		}
 
-		if (!RESPONSE.isSent())
+		if (!RESPONSE.isProcessed())
 		{
 			LoggerProxy.Warning("Unfinished server response.");
 		}

--- a/packages/architectura/src/definition/_index.mts
+++ b/packages/architectura/src/definition/_index.mts
@@ -1,1 +1,2 @@
 export * from "./enum/_index.mjs";
+export * from "./interface/_index.mjs";

--- a/packages/architectura/src/definition/interface/_index.mts
+++ b/packages/architectura/src/definition/interface/_index.mts
@@ -1,0 +1,1 @@
+export * from "./error-with-code.interface.mjs";

--- a/packages/architectura/src/definition/interface/error-with-code.interface.mts
+++ b/packages/architectura/src/definition/interface/error-with-code.interface.mts
@@ -1,0 +1,6 @@
+interface ErrorWithCodeInterface extends Error
+{
+	code: string;
+}
+
+export type { ErrorWithCodeInterface };

--- a/packages/architectura/src/predicate/_index.mts
+++ b/packages/architectura/src/predicate/_index.mts
@@ -1,0 +1,1 @@
+export * from "./is-error-with-code.mjs";

--- a/packages/architectura/src/predicate/is-error-with-code.mts
+++ b/packages/architectura/src/predicate/is-error-with-code.mts
@@ -1,0 +1,9 @@
+import type { ErrorWithCodeInterface } from "../definition/interface/error-with-code.interface.mjs";
+import { hasProperty, isString } from "@vitruvius-labs/ts-predicate/type-guard";
+
+function isErrorWithCode(value: unknown): value is ErrorWithCodeInterface
+{
+	return value instanceof Error && hasProperty(value, "code", isString);
+}
+
+export { isErrorWithCode };

--- a/packages/architectura/src/service/file-system/_index.mts
+++ b/packages/architectura/src/service/file-system/_index.mts
@@ -1,2 +1,1 @@
-export * from "./definition/_index.mjs";
 export * from "./file-system.service.mjs";

--- a/packages/architectura/src/service/file-system/definition/_index.mts
+++ b/packages/architectura/src/service/file-system/definition/_index.mts
@@ -1,1 +1,0 @@
-export * from "./interface/_index.mjs";

--- a/packages/architectura/src/service/file-system/definition/interface/_index.mts
+++ b/packages/architectura/src/service/file-system/definition/interface/_index.mts
@@ -1,1 +1,0 @@
-export * from "./file-system-error.interface.mjs";

--- a/packages/architectura/src/service/file-system/definition/interface/file-system-error.interface.mts
+++ b/packages/architectura/src/service/file-system/definition/interface/file-system-error.interface.mts
@@ -1,6 +1,0 @@
-interface FileSystemErrorInterface extends Error
-{
-	code: string;
-}
-
-export type { FileSystemErrorInterface };

--- a/packages/architectura/src/service/file-system/file-system.service.mts
+++ b/packages/architectura/src/service/file-system/file-system.service.mts
@@ -1,20 +1,10 @@
 import { type Dirent, type ReadStream, type Stats, createReadStream } from "node:fs";
 import { type FileHandle, open, readFile, readdir, stat } from "node:fs/promises";
-import { hasProperty, isInstanceOf, isString } from "@vitruvius-labs/ts-predicate/type-guard";
-import type { FileSystemErrorInterface } from "./definition/interface/file-system-error.interface.mjs";
 import { LoggerProxy } from "../../service/logger/logger.proxy.mjs";
+import { isErrorWithCode } from "../../predicate/is-error-with-code.mjs";
 
 class FileSystemService
 {
-	public static IsFileSystemError(this: void, error: unknown): error is FileSystemErrorInterface
-	{
-		return (
-			isInstanceOf(error, Error)
-			&& hasProperty(error, "code")
-			&& isString(error.code)
-		);
-	}
-
 	public static async DirectoryExists(directory_path: string): Promise<boolean>
 	{
 		const STAT: Stats | undefined = await FileSystemService.GetStats(directory_path);
@@ -107,7 +97,7 @@ class FileSystemService
 		return FILE;
 	}
 
-	public static async OpenFile(this: void, file_path: string, flags: string): Promise<FileHandle>
+	public static async OpenFile(file_path: string, flags: string): Promise<FileHandle>
 	{
 		const EXISTS: boolean = await FileSystemService.FileExists(file_path);
 
@@ -121,7 +111,7 @@ class FileSystemService
 		return FILE;
 	}
 
-	public static async GetStats(this: void, path: string): Promise<Stats | undefined>
+	public static async GetStats(path: string): Promise<Stats | undefined>
 	{
 		try
 		{
@@ -129,7 +119,7 @@ class FileSystemService
 		}
 		catch (error: unknown)
 		{
-			if (FileSystemService.IsFileSystemError(error))
+			if (isErrorWithCode(error))
 			{
 				switch (error.code)
 				{
@@ -156,7 +146,7 @@ class FileSystemService
 	/**
 	* This dynamic import proxy method allows mocking dynamic imports in your tests.
 	*/
-	public static async Import(this: void, path: string): Promise<unknown>
+	public static async Import(path: string): Promise<unknown>
 	{
 		const MODULE: unknown = await import(path);
 

--- a/packages/ts-predicate/docs/type-assertion.md
+++ b/packages/ts-predicate/docs/type-assertion.md
@@ -1,3 +1,14 @@
+# Test
+
+When validating a composite value, you may provide tests for its constituents.
+
+```ts
+type Test<T> =
+	| (item: unknown) => asserts item is T
+	| (item: unknown) => item is T
+;
+```
+
 # TypeAssertion
 
 ## AssertDefined
@@ -118,11 +129,6 @@ interface RecordConstraints<T>
 {
 	itemTest?: Test<T>;
 }
-
-type Test<T> =
-	| (item: unknown) => asserts item is T
-	| (item: unknown) => item is T
-;
 ```
 
 If `itemTest` is provided, it'll asserts that the predicate hold true for every item.
@@ -180,7 +186,7 @@ nullish.
 ## AssertProperty
 
 ```ts
-assertProperty(value: object, property: string): void
+assertProperty<T>(value: object, property: string, test?: Test<T>): void
 ```
 
 Asserts that the value is an object with the property defined.
@@ -244,6 +250,14 @@ assertUnion(value: unknown, tests: Array<TestFunction>): void
 
 Test a value against the union of different test functions. As long as one pass, it passes.
 
+## Unary
+
+```ts
+unary(test_function: ((value: unknown, options: Options) => void), ...parameters: Array<Options>): ((value: unknown) => void)
+```
+
+Helper function for creating closures of test functions with their configuration options.
+
 # ValidationError
 
 To distinguish between unexpected errors and validation errors, you can check that the caught error is an instance of `ValidationError`.
@@ -256,11 +270,3 @@ Any custom assertion must throw a `ValidationError` unless an unexpected error o
 When a provided callable throws anything but an instance of `Error`, an instance of `UnknownError` will be created.
 
 You can get the original thrown value from the `reason` property.
-
-# Unary
-
-```ts
-unary(test_function: ((value: unknown, options: Options) => void), ...parameters: Array<Options>): ((value: unknown) => void)
-```
-
-Helper function for creating closures of test functions with their configuration options.

--- a/packages/ts-predicate/docs/type-guard.md
+++ b/packages/ts-predicate/docs/type-guard.md
@@ -1,3 +1,14 @@
+# Test
+
+When validating a composite value, you may provide tests for its constituents.
+
+```ts
+type Test<T> =
+	| (item: unknown) => asserts item is T
+	| (item: unknown) => item is T
+;
+```
+
 # TypeGuard
 
 ## IsPrimitive
@@ -88,11 +99,6 @@ interface ArrayConstraints<T>
 	minLength?: number;
 	itemTest?: Test<T>;
 }
-
-type Test<T> =
-	| (item: unknown) => asserts item is T
-	| (item: unknown) => item is T
-;
 ```
 
 If `minLength` is provided, it'll confirm that the value has at least that many items.
@@ -185,7 +191,7 @@ Narrow down the value to being an object with the property defined, though it ma
 ## HasProperty
 
 ```ts
-hasProperty(value: object, property: string): boolean
+hasProperty<T>(value: object, property: string, test?: Test<T>): boolean
 ```
 
 Narrow down the value to being an object with the property defined.
@@ -249,7 +255,7 @@ isUnion(value: unknown, tests: Array<TestFunction>): boolean
 
 Test a value against the union of different test functions. As long as one pass, it passes.
 
-# Unary
+## Unary
 
 ```ts
 unary(test_function: ((value: unknown, options: Options) => boolean), ...parameters: Array<Options>): ((value: unknown) => boolean)

--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/ts-predicate",
-	"version": "5.0.2",
+	"version": "5.0.3",
 	"description": "TypeScript predicates library",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/ts-predicate/src/definition/type/object-with-property.mts
+++ b/packages/ts-predicate/src/definition/type/object-with-property.mts
@@ -1,5 +1,5 @@
-type ObjectWithProperty<O extends object, K extends string> = O & {
-	[property in K]: K extends keyof O ? NonNullable<O[K]> : unknown;
+type ObjectWithProperty<O extends object, K extends string, T> = O & {
+	[property in K]: K extends keyof O ? NonNullable<O[K]> : T;
 };
 
 export type { ObjectWithProperty };

--- a/packages/ts-predicate/src/type-assertion/assert-allowed-keys.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-allowed-keys.mts
@@ -1,6 +1,6 @@
 import { ValidationError } from "./utils/validation-error.mjs";
 
-function assertAllowedKeys(value: Record<string, unknown>, allowed_keys: Array<string>): void
+function assertAllowedKeys(value: object, allowed_keys: Array<string>): void
 {
 	const FORBIDDEN_PROPERTIES: Array<string> = Object.keys(value).filter(
 		(key: string): boolean =>

--- a/packages/ts-predicate/src/type-assertion/assert-nullable-property.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-nullable-property.mts
@@ -1,4 +1,4 @@
-import type { ObjectWithNullableProperty } from "../definition/_index.mjs";
+import type { ObjectWithNullableProperty } from "../definition/type/object-with-nullable-property.mjs";
 import { hasNullableProperty } from "../type-guard/has-nullable-property.mjs";
 import { ValidationError } from "./utils/validation-error.mjs";
 

--- a/packages/ts-predicate/src/type-assertion/assert-property.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-property.mts
@@ -1,18 +1,26 @@
-import type { ObjectWithProperty } from "../definition/_index.mjs";
+import type { ObjectWithProperty } from "../definition/type/object-with-property.mjs";
+import type { Test } from "../definition/type/test.mjs";
 import { isDefined } from "../type-guard/is-defined.mjs";
 import { assertNullableProperty } from "./assert-nullable-property.mjs";
+import { itemAssertion } from "./utils/item-assertion.mjs";
 import { ValidationError } from "./utils/validation-error.mjs";
 
-function assertProperty<O extends object, K extends string>(
+function assertProperty<O extends object, K extends string, T>(
 	value: O,
-	property: K
-): asserts value is ObjectWithProperty<O, K>
+	property: K,
+	test?: Test<T>
+): asserts value is ObjectWithProperty<O, K, T>
 {
 	assertNullableProperty<O, K>(value, property);
 
 	if (!isDefined(value[property]))
 	{
 		throw new ValidationError(`The property "${property}" must not have a nullish value (undefined, null, or NaN).`);
+	}
+
+	if (test !== undefined)
+	{
+		itemAssertion<T>(value[property], test);
 	}
 }
 

--- a/packages/ts-predicate/src/type-guard/has-allowed-keys.mts
+++ b/packages/ts-predicate/src/type-guard/has-allowed-keys.mts
@@ -1,4 +1,4 @@
-function hasAllowedKeys(value: Record<string, unknown>, allowed_keys: Array<string>): boolean
+function hasAllowedKeys(value: object, allowed_keys: Array<string>): boolean
 {
 	return Object.keys(value).every(
 		(key: string): boolean =>

--- a/packages/ts-predicate/src/type-guard/has-nullable-property.mts
+++ b/packages/ts-predicate/src/type-guard/has-nullable-property.mts
@@ -1,4 +1,4 @@
-import type { ObjectWithNullableProperty } from "../definition/_index.mjs";
+import type { ObjectWithNullableProperty } from "../definition/type/object-with-nullable-property.mjs";
 
 function hasNullableProperty<O extends object, K extends string>(
 	value: O,

--- a/packages/ts-predicate/src/type-guard/has-property.mts
+++ b/packages/ts-predicate/src/type-guard/has-property.mts
@@ -1,13 +1,20 @@
-import type { ObjectWithProperty } from "../definition/_index.mjs";
+import type { ObjectWithProperty } from "../definition/type/object-with-property.mjs";
+import type { Test } from "../definition/type/test.mjs";
 import { hasNullableProperty } from "./has-nullable-property.mjs";
 import { isDefined } from "./is-defined.mjs";
+import { itemGuard } from "./utils/item-guard.mjs";
 
-function hasProperty<O extends object, K extends string>(
+function hasProperty<O extends object, K extends string, T>(
 	value: O,
-	property: K
-): value is ObjectWithProperty<O, K>
+	property: K,
+	test?: Test<T>
+): value is ObjectWithProperty<O, K, T>
 {
-	return hasNullableProperty(value, property) && isDefined(value[property]);
+	return (
+		hasNullableProperty(value, property)
+		&& isDefined(value[property])
+		&& (test === undefined || itemGuard<T>(value[property], test))
+	);
 }
 
 export { hasProperty };

--- a/packages/ts-predicate/test/type-assertion/assert-property.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-property.spec.mts
@@ -30,4 +30,22 @@ describe("TypeAssertion.assertProperty", (): void => {
 
 		doesNotThrow(WRAPPER);
 	});
+
+	it("should throw when given an object with the property, but the value is of the wrong type", (): void => {
+		const WRAPPER = (): void =>
+		{
+			TypeAssertion.assertProperty({ answer: "lorem ipsum" }, "answer", TypeAssertion.assertNumber);
+		};
+
+		throws(WRAPPER, createErrorTest("The value must be a number."));
+	});
+
+	it("should return when given an object with the property and the value is of the correct type", (): void => {
+		const WRAPPER = (): void =>
+		{
+			TypeAssertion.assertProperty({ answer: 42 }, "answer", TypeAssertion.assertNumber);
+		};
+
+		doesNotThrow(WRAPPER);
+	});
 });

--- a/packages/ts-predicate/test/type-guard/has-property.spec.mts
+++ b/packages/ts-predicate/test/type-guard/has-property.spec.mts
@@ -31,4 +31,26 @@ describe("TypeGuard.hasProperty", (): void => {
 			strictEqual(RESULT, true);
 		}
 	});
+
+	it("should return false when given an object with the property and the property is of the wrong type", (): void => {
+		const VALUES: Array<unknown> = getInvertedValues(GroupType.NULLISH, GroupType.STRING);
+
+		for (const ITEM of VALUES)
+		{
+			const RESULT: unknown = TypeGuard.hasProperty({ answer: ITEM }, "answer", TypeGuard.isString);
+
+			strictEqual(RESULT, false);
+		}
+	});
+
+	it("should return true when given an object with the property and the property is of the correct type", (): void => {
+		const VALUES: Array<unknown> = getValues(GroupType.STRING);
+
+		for (const ITEM of VALUES)
+		{
+			const RESULT: unknown = TypeGuard.hasProperty({ answer: ITEM }, "answer", TypeGuard.isString);
+
+			strictEqual(RESULT, true);
+		}
+	});
 });


### PR DESCRIPTION
- [x] ts-predicate
  - [x] Updated semver
  - [x] Updated documentation
  - [x] hasProperty: Added optional test
  - [x] assertProperty: Added optional test
- [x] architectura 
  - [x] Added general predicate `isErrorWithCode`
  - [x] Added `RichServerResponse` property `processed`
  - [x] Ignore native state flags on response and use custom flags instead 