### PR TITLE
fix: predicate instanceof work with abstract classes

### DIFF
--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/ts-predicate",
-	"version": "5.3.0",
+	"version": "5.4.0",
 	"description": "TypeScript predicates library",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/ts-predicate/src/type-assertion/assert-instance-of.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-instance-of.mts
@@ -1,7 +1,7 @@
-import type { ConstructorOf } from "../helper/definition/type/constructor-of.mjs";
+import type { AbstractConstructorOf } from "../helper/definition/type/abstract-constructor-of.mjs";
 import { ValidationError } from "./utils/validation-error.mjs";
 
-function assertInstanceOf<T extends object>(value: unknown, constructor_class: ConstructorOf<T>): asserts value is InstanceType<typeof constructor_class>
+function assertInstanceOf<T extends object>(value: unknown, constructor_class: AbstractConstructorOf<T>): asserts value is InstanceType<typeof constructor_class>
 {
 	if (!(value instanceof constructor_class))
 	{

--- a/packages/ts-predicate/src/type-guard/is-instance-of.mts
+++ b/packages/ts-predicate/src/type-guard/is-instance-of.mts
@@ -1,6 +1,6 @@
-import type { ConstructorOf } from "../helper/definition/type/constructor-of.mjs";
+import type { AbstractConstructorOf } from "../helper/definition/type/abstract-constructor-of.mjs";
 
-function isInstanceOf<T extends object>(value: unknown, constructor_class: ConstructorOf<T>): value is InstanceType<typeof constructor_class>
+function isInstanceOf<T extends object>(value: unknown, constructor_class: AbstractConstructorOf<T>): value is InstanceType<typeof constructor_class>
 {
 	return value instanceof constructor_class;
 }

--- a/packages/ts-predicate/test/type-assertion/assert-instance-of.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-instance-of.spec.mts
@@ -21,4 +21,14 @@ describe("TypeAssertion.assertInstanceOf", (): void => {
 			throws(WRAPPER, createErrorTest());
 		}
 	});
+
+	it("should support abstract classes", (): void => {
+		abstract class Parent {}
+
+		class Child extends Parent {}
+
+		const CHILD: Child = new Child();
+
+		TypeAssertion.assertInstanceOf(CHILD, Parent);
+	});
 });

--- a/packages/ts-predicate/test/type-guard/is-instance-of.spec.mts
+++ b/packages/ts-predicate/test/type-guard/is-instance-of.spec.mts
@@ -16,4 +16,14 @@ describe("TypeGuard.isInstanceOf", (): void => {
 			strictEqual(TypeGuard.isInstanceOf(ITEM, Date), false);
 		}
 	});
+
+	it("should support abstract classes", (): void => {
+		abstract class Parent {}
+
+		class Child extends Parent {}
+
+		const CHILD: Child = new Child();
+
+		strictEqual(TypeGuard.isInstanceOf(CHILD, Parent), true);
+	});
 });


### PR DESCRIPTION
- [x] Updated semver
- [x] Updated unit tests
- [x] `isInstanceOf` now supports abstract constructors
- [x] `assertInstanceOf` now supports abstract constructors