### PR TITLE
feat: repository QoL

### DIFF
--- a/packages/architectura/package.json
+++ b/packages/architectura/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/architectura",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"description": "A light weight strongly typed Node.JS framework providing isolated context for each request.",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/architectura/src/ddd/base.repository.mts
+++ b/packages/architectura/src/ddd/base.repository.mts
@@ -70,7 +70,7 @@ abstract class BaseRepository<
 	 * @remarks
 	 * Used by both the findByUUID and getByUUID methods.
 	 */
-	protected abstract fetchByUUID(uuid: string, options: RepositoryQueryNormalizedOptionsInterface): Promise<(I & ModelMetadataInterface) | undefined>;
+	protected abstract fetchByUUID(uuid: string, options: RepositoryQueryNormalizedOptionsInterface): Promise<(I & ModelMetadataInterface) | null | undefined>;
 
 	/**
 	 * Fetch an entity by its id.
@@ -78,7 +78,7 @@ abstract class BaseRepository<
 	 * @remarks
 	 * Used by both the findById and getById methods.
 	 */
-	protected abstract fetchById(id: bigint, options: RepositoryQueryNormalizedOptionsInterface): Promise<(I & ModelMetadataInterface) | undefined>;
+	protected abstract fetchById(id: bigint, options: RepositoryQueryNormalizedOptionsInterface): Promise<(I & ModelMetadataInterface) | null | undefined>;
 
 	/**
 	 * Register a new entity.
@@ -129,9 +129,9 @@ abstract class BaseRepository<
 	{
 		const normalized_options: RepositoryQueryNormalizedOptionsInterface = BaseRepository.NormalizeOptions(options);
 
-		const data: (I & ModelMetadataInterface) | undefined = await this.fetchByUUID(uuid, normalized_options);
+		const data: (I & ModelMetadataInterface) | null | undefined = await this.fetchByUUID(uuid, normalized_options);
 
-		if (data === undefined)
+		if (!isDefined(data))
 		{
 			return undefined;
 		}
@@ -175,9 +175,9 @@ abstract class BaseRepository<
 	{
 		const normalized_options: RepositoryQueryNormalizedOptionsInterface = BaseRepository.NormalizeOptions(options);
 
-		const data: (I & ModelMetadataInterface) | undefined = await this.fetchById(id, normalized_options);
+		const data: (I & ModelMetadataInterface) | null | undefined = await this.fetchById(id, normalized_options);
 
-		if (data === undefined)
+		if (!isDefined(data))
 		{
 			return undefined;
 		}

--- a/packages/architectura/test/ddd/base.repository.spec.mts
+++ b/packages/architectura/test/ddd/base.repository.spec.mts
@@ -76,11 +76,24 @@ describe("BaseRepository", (): void => {
 	});
 
 	describe("findByUUID", (): void => {
-		it("should return undefined if no entity with this UUID exists", async (): Promise<void> => {
+		it("should return undefined if no entity with this UUID exists (undefined return)", async (): Promise<void> => {
 			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
 			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
 
 			FETCH_UUID_STUB.resolves(undefined);
+
+			const RESULT: unknown = REPOSITORY.findByUUID("00000000-0000-0000-0000-000000000000");
+
+			instanceOf(RESULT, Promise);
+			await doesNotReject(RESULT);
+			strictEqual(await RESULT, undefined);
+		});
+
+		it("should return undefined if no entity with this UUID exists (null returned)", async (): Promise<void> => {
+			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
+			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
+
+			FETCH_UUID_STUB.resolves(null);
 
 			const RESULT: unknown = REPOSITORY.findByUUID("00000000-0000-0000-0000-000000000000");
 
@@ -138,11 +151,20 @@ describe("BaseRepository", (): void => {
 	});
 
 	describe("getByUUID", (): void => {
-		it("should throw if no entity with this UUID exists", async (): Promise<void> => {
+		it("should throw if no entity with this UUID exists (undefined returned)", async (): Promise<void> => {
 			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
 			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
 
 			FETCH_UUID_STUB.resolves(undefined);
+
+			await rejects(REPOSITORY.getByUUID("00000000-0000-0000-0000-000000000000"), createErrorTest());
+		});
+
+		it("should throw if no entity with this UUID exists (null returned)", async (): Promise<void> => {
+			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
+			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
+
+			FETCH_UUID_STUB.resolves(null);
 
 			await rejects(REPOSITORY.getByUUID("00000000-0000-0000-0000-000000000000"), createErrorTest());
 		});
@@ -192,11 +214,24 @@ describe("BaseRepository", (): void => {
 	});
 
 	describe("findById", (): void => {
-		it("should return undefined if no entity with this id exists", async (): Promise<void> => {
+		it("should return undefined if no entity with this id exists (undefined return)", async (): Promise<void> => {
 			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
 			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
 
 			FETCH_ID_STUB.resolves(undefined);
+
+			const RESULT: unknown = REPOSITORY.findById(1n);
+
+			instanceOf(RESULT, Promise);
+			await doesNotReject(RESULT);
+			strictEqual(await RESULT, undefined);
+		});
+
+		it("should return undefined if no entity with this id exists (null return)", async (): Promise<void> => {
+			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
+			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
+
+			FETCH_ID_STUB.resolves(null);
 
 			const RESULT: unknown = REPOSITORY.findById(1n);
 
@@ -254,11 +289,20 @@ describe("BaseRepository", (): void => {
 	});
 
 	describe("getById", (): void => {
-		it("should throw if no entity with this id exists", async (): Promise<void> => {
+		it("should throw if no entity with this id exists (undefined return)", async (): Promise<void> => {
 			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
 			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
 
 			FETCH_ID_STUB.resolves(undefined);
+
+			await rejects(REPOSITORY.getById(1n), createErrorTest());
+		});
+
+		it("should throw if no entity with this id exists (null return)", async (): Promise<void> => {
+			const FACTORY: DummySimpleFactory = new DummySimpleFactory(DummyModel);
+			const REPOSITORY: DummyBaseRepository = new DummyBaseRepository(FACTORY);
+
+			FETCH_ID_STUB.resolves(null);
 
 			await rejects(REPOSITORY.getById(1n), createErrorTest());
 		});


### PR DESCRIPTION
- [x] Updated semver
- [x] Updated unit tests
- [x] Repository QOL
  - [x] Abstract method `fetchById` can now return null too when no entity is found.
  - [x] Abstract method `fetchByUUID` can now return null too when no entity is found.