### PR TITLE
fix: direct instance of predicate

### DIFF
--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/ts-predicate",
-	"version": "5.4.0",
+	"version": "5.4.1",
 	"description": "TypeScript predicates library",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/ts-predicate/src/type-assertion/assert-instance-of.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-instance-of.mts
@@ -1,7 +1,7 @@
 import type { AbstractConstructorOf } from "../helper/definition/type/abstract-constructor-of.mjs";
 import { ValidationError } from "./utils/validation-error.mjs";
 
-function assertInstanceOf<T extends object>(value: unknown, constructor_class: AbstractConstructorOf<T>): asserts value is InstanceType<typeof constructor_class>
+function assertInstanceOf<T extends object>(value: unknown, constructor_class: AbstractConstructorOf<T>): asserts value is T
 {
 	if (!(value instanceof constructor_class))
 	{

--- a/packages/ts-predicate/src/type-guard/is-instance-of.mts
+++ b/packages/ts-predicate/src/type-guard/is-instance-of.mts
@@ -1,6 +1,6 @@
 import type { AbstractConstructorOf } from "../helper/definition/type/abstract-constructor-of.mjs";
 
-function isInstanceOf<T extends object>(value: unknown, constructor_class: AbstractConstructorOf<T>): value is InstanceType<typeof constructor_class>
+function isInstanceOf<T extends object>(value: unknown, constructor_class: AbstractConstructorOf<T>): value is T
 {
 	return value instanceof constructor_class;
 }

--- a/packages/ts-predicate/test/type-assertion/assert-instance-of.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-instance-of.spec.mts
@@ -1,4 +1,4 @@
-import { throws } from "node:assert";
+import { strictEqual, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { TypeAssertion } from "../../src/_index.mjs";
 import { createErrorTest, getAllValues } from "@vitruvius-labs/testing-ground";
@@ -30,5 +30,13 @@ describe("TypeAssertion.assertInstanceOf", (): void => {
 		const CHILD: Child = new Child();
 
 		TypeAssertion.assertInstanceOf(CHILD, Parent);
+	});
+
+	it("should narrow type in typescript too", (): void => {
+		const DUMMY: unknown = new Date(0);
+
+		TypeAssertion.assertInstanceOf(DUMMY, Date);
+
+		strictEqual(DUMMY.getTime(), 0);
 	});
 });

--- a/packages/ts-predicate/test/type-guard/is-instance-of.spec.mts
+++ b/packages/ts-predicate/test/type-guard/is-instance-of.spec.mts
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert";
+import { fail, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import { TypeGuard } from "../../src/_index.mjs";
 import { getAllValues } from "@vitruvius-labs/testing-ground";
@@ -25,5 +25,18 @@ describe("TypeGuard.isInstanceOf", (): void => {
 		const CHILD: Child = new Child();
 
 		strictEqual(TypeGuard.isInstanceOf(CHILD, Parent), true);
+	});
+
+	it("should narrow type in typescript too", (): void => {
+		const DUMMY: unknown = new Date(0);
+
+		if (TypeGuard.isInstanceOf(DUMMY, Date))
+		{
+			strictEqual(DUMMY.getTime(), 0);
+		}
+		else
+		{
+			fail("TypeGuard.isInstanceOf() failed to narrow the type.");
+		}
 	});
 });


### PR DESCRIPTION
- [x] Updated semver
- [x] Updated test units
- [x] In some complex cases, `isInstanceOf` and `assertInstanceOf` asserted the given value to be `any`.