### PR TITLE
feat: object helpers / fix: abstract constructor of

### DIFF
--- a/packages/ts-predicate/documentation/helper.md
+++ b/packages/ts-predicate/documentation/helper.md
@@ -24,6 +24,18 @@ Return the constructor class for the given object.
 
 Throws if the object has no prototype or no constructor in its prototype.
 
+Allows instantiating the returned value if it's not abstract.
+
+## Keys
+
+```ts
+keys(value: T): Array<keyof T>
+```
+
+Return the keys of the given object typed as the keys.
+
+It presumes that no extraneous keys were added from a child class or derived type.
+
 ## NormalizeErrorTree
 
 ```ts

--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/ts-predicate",
-	"version": "6.0.0",
+	"version": "6.1.0",
 	"description": "TypeScript predicates library",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/ts-predicate/src/helper/_index.mts
+++ b/packages/ts-predicate/src/helper/_index.mts
@@ -2,6 +2,7 @@ export * from "./definition/_index.mjs";
 export * from "./utils/unknown-error.mjs";
 export * from "./get-constructor-of.mjs";
 export * from "./is-similar.mjs";
+export * from "./keys.mjs";
 export * from "./normalize-error-tree.mjs";
 export * from "./stringify-error-tree.mjs";
 export * from "./to-error.mjs";

--- a/packages/ts-predicate/src/helper/definition/type/abstract-constructor-of.mts
+++ b/packages/ts-predicate/src/helper/definition/type/abstract-constructor-of.mts
@@ -1,4 +1,4 @@
 // eslint-disable-next-line @ts/no-explicit-any,@ts/array-type -- Constructors are complicated to type
-type AbstractConstructorOf<T extends object> = (new (...args: any[]) => T) | (abstract new (...args: any) => any) ;
+type AbstractConstructorOf<T extends object> = abstract new (...args: any[]) => T;
 
 export type { AbstractConstructorOf };

--- a/packages/ts-predicate/src/helper/get-constructor-of.mts
+++ b/packages/ts-predicate/src/helper/get-constructor-of.mts
@@ -1,6 +1,6 @@
-import type { ConstructorOf } from "./definition/type/constructor-of.mjs";
+import type { AbstractConstructorOf } from "./definition/type/abstract-constructor-of.mjs";
 
-function getConstructorOf<T extends object, C extends ConstructorOf<T>>(value: T): C
+function getConstructorOf<T extends object, C extends AbstractConstructorOf<T>>(value: T): C
 {
 	// eslint-disable-next-line @ts/no-unsafe-assignment -- Object.getPrototypeOf is badly typed
 	const PROTOTYPE: object | null = Object.getPrototypeOf(value);

--- a/packages/ts-predicate/src/helper/get-constructor-of.mts
+++ b/packages/ts-predicate/src/helper/get-constructor-of.mts
@@ -1,6 +1,7 @@
 import type { AbstractConstructorOf } from "./definition/type/abstract-constructor-of.mjs";
+import type { ConstructorOf } from "./definition/type/constructor-of.mjs";
 
-function getConstructorOf<T extends object, C extends AbstractConstructorOf<T>>(value: T): C
+function getConstructorOf<T extends object, C extends AbstractConstructorOf<T> = ConstructorOf<T>>(value: T): C
 {
 	// eslint-disable-next-line @ts/no-unsafe-assignment -- Object.getPrototypeOf is badly typed
 	const PROTOTYPE: object | null = Object.getPrototypeOf(value);

--- a/packages/ts-predicate/src/helper/keys.mts
+++ b/packages/ts-predicate/src/helper/keys.mts
@@ -1,0 +1,7 @@
+function keys<T extends object>(value: T): Array<keyof T>
+{
+	// @ts-expect-error: Presume no extraneous keys
+	return Object.keys(value);
+}
+
+export { keys };

--- a/packages/ts-predicate/test/helper/get-constructor-of.spec.mts
+++ b/packages/ts-predicate/test/helper/get-constructor-of.spec.mts
@@ -1,7 +1,7 @@
-import { strictEqual, throws } from "node:assert";
+import { deepStrictEqual, strictEqual, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { Helper } from "../../src/_index.mjs";
-import { createErrorTest } from "@vitruvius-labs/testing-ground";
+import { createErrorTest, createValue } from "@vitruvius-labs/testing-ground";
 
 describe("Helper.getConstructorOf", (): void => {
 	it("should return the constructor of the given object", (): void => {
@@ -26,5 +26,37 @@ describe("Helper.getConstructorOf", (): void => {
 		};
 
 		throws(WRAPPER, createErrorTest("The value has no constructor."));
+	});
+
+	it("should return a constructor that can be instantiated", (): void => {
+		const EXPECTED: Date = new Date(0);
+
+		const CONSTRUCTOR: typeof Date = Helper.getConstructorOf(EXPECTED);
+
+		const INSTANCE: Date = new CONSTRUCTOR(0);
+
+		deepStrictEqual(INSTANCE, EXPECTED);
+	});
+
+	it("should return a constructor that cannot be instantiated if the class is abstract", (): void => {
+		throws((): void => {
+			abstract class Foo
+			{
+				protected foo: string;
+
+				public constructor(foo: string)
+				{
+					this.foo = foo;
+				}
+
+				public abstract setFoo(foo: string): void;
+				public abstract getFoo(): string;
+			}
+
+			const CONSTRUCTOR: typeof Foo = Helper.getConstructorOf(createValue<Foo>());
+
+			// @ts-expect-error -- Cannot instantiate abstract class
+			new CONSTRUCTOR("foo");
+		});
 	});
 });

--- a/packages/ts-predicate/test/helper/keys.spec.mts
+++ b/packages/ts-predicate/test/helper/keys.spec.mts
@@ -1,0 +1,27 @@
+import { describe, it } from "node:test";
+import { deepStrictEqual } from "node:assert";
+import { Helper } from "../../src/_index.mjs";
+
+describe("Helper.keys", (): void => {
+	it("should return the keys of the given object", (): void => {
+		const VALUE: { a: 0; b: 0 } = { a: 0, b: 0 };
+
+		const KEYS: Array<"a" | "b"> = Helper.keys(VALUE);
+
+		deepStrictEqual(KEYS, ["a", "b"]);
+	});
+
+	it("should return the keys of the given instance", (): void => {
+		class Foo
+		{
+			public a: number = 0;
+			public b: number = 0;
+		}
+
+		const VALUE: Foo = new Foo();
+
+		const KEYS: Array<keyof Foo> = Helper.keys(VALUE);
+
+		deepStrictEqual(KEYS, ["a", "b"]);
+	});
+});


### PR DESCRIPTION
- [x] Updated semver
- [x] Updated unit tests
- [x] Updated documentation
- [x] New helper function `keys`, use with caution as child class or derived type can add unwanted keys
- [x] `getConstructorOf`
  - [x] Loosen constraint to allow abstract constructors, use with caution
- [x] `AbstractConstructorOf`
  - [x] Fix issue with type
  - [x] Simplify type