### PR TITLE
feat: unknown predicates

### DIFF
--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/ts-predicate",
-	"version": "7.1.0",
+	"version": "7.2.0",
 	"description": "TypeScript predicates library",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/ts-predicate/src/type-assertion/_index.mts
+++ b/packages/ts-predicate/src/type-assertion/_index.mts
@@ -23,3 +23,4 @@ export * from "./assert-record.mjs";
 export * from "./assert-string.mjs";
 export * from "./assert-structured-data.mjs";
 export * from "./assert-union.mjs";
+export * from "./assert-unknown.mjs";

--- a/packages/ts-predicate/src/type-assertion/assert-unknown.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-unknown.mts
@@ -1,0 +1,7 @@
+// @ts-expect-error -- Unused parameter is intended
+function assertUnknown(value: unknown): asserts value is unknown
+{
+	// Do nothing
+}
+
+export { assertUnknown };

--- a/packages/ts-predicate/src/type-guard/_index.mts
+++ b/packages/ts-predicate/src/type-guard/_index.mts
@@ -20,3 +20,4 @@ export * from "./is-record.mjs";
 export * from "./is-string.mjs";
 export * from "./is-structured-data.mjs";
 export * from "./is-union.mjs";
+export * from "./is-unknown.mjs";

--- a/packages/ts-predicate/src/type-guard/is-unknown.mts
+++ b/packages/ts-predicate/src/type-guard/is-unknown.mts
@@ -1,0 +1,7 @@
+// @ts-expect-error -- Unused parameter is intended
+function isUnknown(value: unknown): value is unknown
+{
+	return true;
+}
+
+export { isUnknown };

--- a/packages/ts-predicate/test/type-assertion/assert-unknown.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-unknown.spec.mts
@@ -1,0 +1,32 @@
+import { doesNotThrow } from "node:assert";
+import { describe, it } from "node:test";
+import { consumeValue, createValue, getAllValues } from "@vitruvius-labs/testing-ground";
+import { assertUnknown } from "../../src/_index.mjs";
+
+describe("assertUnknown", (): void => {
+	it("should return when given anything", (): void => {
+		const VALUES: Array<unknown> = getAllValues();
+
+		for (const ITEM of VALUES)
+		{
+			const WRAPPER = (): void =>
+			{
+				assertUnknown(ITEM);
+			};
+
+			doesNotThrow(WRAPPER);
+		}
+	});
+
+	it("should narrow the type to unknown", (): void => {
+		const WRAPPER = (): void =>
+		{
+			const VALUE: unknown = createValue();
+
+			assertUnknown(VALUE);
+			consumeValue<unknown>(VALUE);
+		};
+
+		doesNotThrow(WRAPPER);
+	});
+});

--- a/packages/ts-predicate/test/type-guard/is-unknown.spec.mts
+++ b/packages/ts-predicate/test/type-guard/is-unknown.spec.mts
@@ -1,0 +1,31 @@
+import { doesNotThrow, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { consumeValue, createValue, getAllValues } from "@vitruvius-labs/testing-ground";
+import { isUnknown } from "../../src/_index.mjs";
+
+describe("isUnknown", (): void => {
+	it("should always return true", (): void => {
+		const VALUES: Array<unknown> = getAllValues();
+
+		for (const ITEM of VALUES)
+		{
+			const RESULT: unknown = isUnknown(ITEM);
+
+			strictEqual(RESULT, true);
+		}
+	});
+
+	it("should narrow the type to unknown", (): void => {
+		const WRAPPER = (): void =>
+		{
+			const VALUE: unknown = createValue();
+
+			if (isUnknown(VALUE))
+			{
+				consumeValue<unknown>(VALUE);
+			}
+		};
+
+		doesNotThrow(WRAPPER);
+	});
+});


### PR DESCRIPTION
Add `isUnknown` and `assertUnknown` for composing predicates more flexibly in some edge cases.