### PR TITLE
fix: assertion throw ValidationError only

### DIFF
--- a/packages/testing-ground/src/definition/type/error-constructor.type.mts
+++ b/packages/testing-ground/src/definition/type/error-constructor.type.mts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @ts/no-explicit-any
+type ErrorConstructorType = new (...args: any) => Error;
+
+export type { ErrorConstructorType };

--- a/packages/testing-ground/src/utils/compare-errors.mts
+++ b/packages/testing-ground/src/utils/compare-errors.mts
@@ -1,4 +1,5 @@
 import { isValidationError } from "./is-validation-error.mjs";
+import { validateError } from "./validate-error.mjs";
 import { wrapCause } from "./wrap-cause.mjs";
 
 function compareErrors(value: unknown, expected: Error): void
@@ -6,10 +7,7 @@ function compareErrors(value: unknown, expected: Error): void
 	// @ts-expect-error -- constructor is badly typed
 	const CONSTRUCTOR_CLASS: typeof Error = expected.constructor;
 
-	if (!(value instanceof CONSTRUCTOR_CLASS))
-	{
-		throw new Error(`An ${CONSTRUCTOR_CLASS.name} must be thrown.`);
-	}
+	validateError(value, CONSTRUCTOR_CLASS);
 
 	if (value.message !== expected.message)
 	{

--- a/packages/testing-ground/src/utils/create-error-test.mts
+++ b/packages/testing-ground/src/utils/create-error-test.mts
@@ -1,33 +1,37 @@
+import type { ErrorConstructorType } from "../definition/type/error-constructor.type.mjs";
 import { compareErrors } from "./compare-errors.mjs";
+import { validateError } from "./validate-error.mjs";
 
-function createErrorTest(expected_error?: Error | RegExp | string): (value: unknown) => true
+function createErrorTest(expected_error?: Error | ErrorConstructorType | RegExp | string): (value: unknown) => true
 {
 	return (value: unknown): true =>
 	{
-		if (expected_error === undefined || expected_error instanceof RegExp)
-		{
-			if (!(value instanceof Error))
-			{
-				throw new Error("An Error must be thrown.");
-			}
-
-			if (value.message.length === 0)
-			{
-				throw new Error("An error must have a message.");
-			}
-
-			if (expected_error instanceof RegExp && !expected_error.test(value.message))
-			{
-				throw new Error(`Expected error message to match ${expected_error.toString()} but got "${value.message}"`);
-			}
-		}
-		else if (expected_error instanceof Error)
+		if (expected_error instanceof Error)
 		{
 			compareErrors(value, expected_error);
+
+			return true;
 		}
-		else
+
+		if (typeof expected_error === "string")
 		{
 			compareErrors(value, new Error(expected_error));
+
+			return true;
+		}
+
+		if (typeof expected_error === "function")
+		{
+			validateError(value, expected_error);
+
+			return true;
+		}
+
+		validateError(value, Error);
+
+		if (expected_error instanceof RegExp && !expected_error.test(value.message))
+		{
+			throw new Error(`Expected error message to match ${expected_error.toString()} but got "${value.message}".`);
 		}
 
 		return true;

--- a/packages/testing-ground/src/utils/validate-error.mts
+++ b/packages/testing-ground/src/utils/validate-error.mts
@@ -4,7 +4,7 @@ function validateError(value: unknown, error_constructor: ErrorConstructorType):
 {
 	if (!(value instanceof error_constructor))
 	{
-		throw new Error(`An ${error_constructor.name} must be thrown.`);
+		throw new Error(`An instance of ${error_constructor.name} must be thrown.`);
 	}
 
 	if (value.message.length === 0)

--- a/packages/testing-ground/src/utils/validate-error.mts
+++ b/packages/testing-ground/src/utils/validate-error.mts
@@ -1,0 +1,16 @@
+import type { ErrorConstructorType } from "../definition/type/error-constructor.type.mjs";
+
+function validateError(value: unknown, error_constructor: ErrorConstructorType): asserts value is Error
+{
+	if (!(value instanceof error_constructor))
+	{
+		throw new Error(`An ${error_constructor.name} must be thrown.`);
+	}
+
+	if (value.message.length === 0)
+	{
+		throw new Error("An error must have a message.");
+	}
+}
+
+export { validateError };

--- a/packages/ts-predicate/package.json
+++ b/packages/ts-predicate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vitruvius-labs/ts-predicate",
-	"version": "7.2.0",
+	"version": "7.2.1",
 	"description": "TypeScript predicates library",
 	"author": {
 		"name": "VitruviusLabs"

--- a/packages/ts-predicate/src/extended/integer/utils/assert-between.mts
+++ b/packages/ts-predicate/src/extended/integer/utils/assert-between.mts
@@ -1,4 +1,5 @@
 import { assertInteger } from "../../../type-assertion/assert-integer.mjs";
+import { ValidationError } from "../../../type-assertion/utils/validation-error.mjs";
 
 function assertBetween(value: unknown, min: number, max: number): void
 {
@@ -6,7 +7,7 @@ function assertBetween(value: unknown, min: number, max: number): void
 
 	if (value < min || max < value)
 	{
-		throw new RangeError(`Value ${value.toFixed(0)} is not between ${min.toFixed(0)} and ${max.toFixed(0)}.`);
+		throw new ValidationError(`Value ${value.toFixed(0)} is not between ${min.toFixed(0)} and ${max.toFixed(0)}.`);
 	}
 }
 

--- a/packages/ts-predicate/src/type-assertion/assert-nullable.mts
+++ b/packages/ts-predicate/src/type-assertion/assert-nullable.mts
@@ -1,10 +1,11 @@
 import { isNullable } from "../type-guard/is-nullable.mjs";
+import { ValidationError } from "./utils/validation-error.mjs";
 
 function assertNullable(value: unknown): asserts value is null | undefined
 {
 	if (!isNullable(value))
 	{
-		throw new TypeError("Value must be null or undefined.");
+		throw new ValidationError("Value must be null or undefined.");
 	}
 }
 

--- a/packages/ts-predicate/src/utils/build-array-constraints.mts
+++ b/packages/ts-predicate/src/utils/build-array-constraints.mts
@@ -1,6 +1,5 @@
 import type { ArrayConstraints } from "../definition/interface/array-constraints.mjs";
 import type { Test } from "../definition/type/test.mjs";
-import { ValidationError } from "../type-assertion/utils/validation-error.mjs";
 
 /** @internal */
 function buildArrayConstraints<Type>(constraints: ArrayConstraints<Type> | Test<Type> | undefined): ArrayConstraints<Type> | undefined
@@ -14,7 +13,7 @@ function buildArrayConstraints<Type>(constraints: ArrayConstraints<Type> | Test<
 
 	if (constraints?.minLength !== undefined && constraints.minLength < 1)
 	{
-		throw new ValidationError("The minimum length cannot be less than one.");
+		throw new RangeError("The minimum length cannot be less than one.");
 	}
 
 	return constraints;

--- a/packages/ts-predicate/src/utils/build-array-constraints.mts
+++ b/packages/ts-predicate/src/utils/build-array-constraints.mts
@@ -1,5 +1,6 @@
 import type { ArrayConstraints } from "../definition/interface/array-constraints.mjs";
 import type { Test } from "../definition/type/test.mjs";
+import { ValidationError } from "../type-assertion/utils/validation-error.mjs";
 
 /** @internal */
 function buildArrayConstraints<Type>(constraints: ArrayConstraints<Type> | Test<Type> | undefined): ArrayConstraints<Type> | undefined
@@ -13,7 +14,7 @@ function buildArrayConstraints<Type>(constraints: ArrayConstraints<Type> | Test<
 
 	if (constraints?.minLength !== undefined && constraints.minLength < 1)
 	{
-		throw new RangeError("The minimum length cannot be less than one.");
+		throw new ValidationError("The minimum length cannot be less than one.");
 	}
 
 	return constraints;

--- a/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-int16.spec.mts
+++ b/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-int16.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertInt16 } from "../../../../../src/_index.mjs";
+import { ValidationError, assertInt16 } from "../../../../../src/_index.mjs";
 import { IntegerBoundaryEnum } from "../../../../../src/extended/integer/definition/enum/integer-boundary.enum.mjs";
 
 describe("assertInt16", (): void => {
@@ -40,7 +40,7 @@ describe("assertInt16", (): void => {
 				assertInt16(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -54,7 +54,7 @@ describe("assertInt16", (): void => {
 				assertInt16(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -68,7 +68,7 @@ describe("assertInt16", (): void => {
 				assertInt16(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-int32.spec.mts
+++ b/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-int32.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertInt32 } from "../../../../../src/_index.mjs";
+import { ValidationError, assertInt32 } from "../../../../../src/_index.mjs";
 import { IntegerBoundaryEnum } from "../../../../../src/extended/integer/definition/enum/integer-boundary.enum.mjs";
 
 describe("assertInt32", (): void => {
@@ -40,7 +40,7 @@ describe("assertInt32", (): void => {
 				assertInt32(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -54,7 +54,7 @@ describe("assertInt32", (): void => {
 				assertInt32(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -68,7 +68,7 @@ describe("assertInt32", (): void => {
 				assertInt32(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-int8.spec.mts
+++ b/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-int8.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertInt8 } from "../../../../../src/_index.mjs";
+import { ValidationError, assertInt8 } from "../../../../../src/_index.mjs";
 import { IntegerBoundaryEnum } from "../../../../../src/extended/integer/definition/enum/integer-boundary.enum.mjs";
 
 describe("assertInt8", (): void => {
@@ -40,7 +40,7 @@ describe("assertInt8", (): void => {
 				assertInt8(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -54,7 +54,7 @@ describe("assertInt8", (): void => {
 				assertInt8(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -68,7 +68,7 @@ describe("assertInt8", (): void => {
 				assertInt8(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-uint16.spec.mts
+++ b/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-uint16.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertUInt16 } from "../../../../../src/_index.mjs";
+import { ValidationError, assertUInt16 } from "../../../../../src/_index.mjs";
 import { IntegerBoundaryEnum } from "../../../../../src/extended/integer/definition/enum/integer-boundary.enum.mjs";
 
 describe("assertUInt16", (): void => {
@@ -34,7 +34,7 @@ describe("assertUInt16", (): void => {
 				assertUInt16(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -48,7 +48,7 @@ describe("assertUInt16", (): void => {
 				assertUInt16(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -62,7 +62,7 @@ describe("assertUInt16", (): void => {
 				assertUInt16(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-uint32.spec.mts
+++ b/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-uint32.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertUInt32 } from "../../../../../src/_index.mjs";
+import { ValidationError, assertUInt32 } from "../../../../../src/_index.mjs";
 import { IntegerBoundaryEnum } from "../../../../../src/extended/integer/definition/enum/integer-boundary.enum.mjs";
 
 describe("assertUInt32", (): void => {
@@ -34,7 +34,7 @@ describe("assertUInt32", (): void => {
 				assertUInt32(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -48,7 +48,7 @@ describe("assertUInt32", (): void => {
 				assertUInt32(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -62,7 +62,7 @@ describe("assertUInt32", (): void => {
 				assertUInt32(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-uint8.spec.mts
+++ b/packages/ts-predicate/test/extended/integer/predicate/type-assertion/assert-uint8.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertUInt8 } from "../../../../../src/_index.mjs";
+import { ValidationError, assertUInt8 } from "../../../../../src/_index.mjs";
 import { IntegerBoundaryEnum } from "../../../../../src/extended/integer/definition/enum/integer-boundary.enum.mjs";
 
 describe("assertUInt8", (): void => {
@@ -34,7 +34,7 @@ describe("assertUInt8", (): void => {
 				assertUInt8(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -48,7 +48,7 @@ describe("assertUInt8", (): void => {
 				assertUInt8(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -62,7 +62,7 @@ describe("assertUInt8", (): void => {
 				assertUInt8(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/extended/nullish/predicate/type-assertion/assert-nullish-property.spec.mts
+++ b/packages/ts-predicate/test/extended/nullish/predicate/type-assertion/assert-nullish-property.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { consumeValue, createErrorTest, createValue } from "@vitruvius-labs/testing-ground";
-import { type Nullish, assertNullishProperty, assertString } from "../../../../../src/_index.mjs";
+import { type Nullish, ValidationError, assertNullishProperty, assertString } from "../../../../../src/_index.mjs";
 
 describe("assertNullishProperty", (): void => {
 	it("should throw when given an object without the property", (): void => {
@@ -15,8 +15,8 @@ describe("assertNullishProperty", (): void => {
 			assertNullishProperty({}, SYMBOL);
 		};
 
-		throws(WRAPPER_STRING, createErrorTest("The value must have a property \"key\"."));
-		throws(WRAPPER_SYMBOL, createErrorTest("The value must have a property \"Symbol(key)\"."));
+		throws(WRAPPER_STRING, createErrorTest(new ValidationError("The value must have a property \"key\".")));
+		throws(WRAPPER_SYMBOL, createErrorTest(new ValidationError("The value must have a property \"Symbol(key)\".")));
 	});
 
 	it("should return when given an object with the property", (): void => {
@@ -42,7 +42,7 @@ describe("assertNullishProperty", (): void => {
 			consumeValue<{ key: unknown }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "key".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "key".')));
 	});
 
 	it("should narrow the type to an object with the corresponding property (symbol)", (): void => {
@@ -55,7 +55,7 @@ describe("assertNullishProperty", (): void => {
 			consumeValue<{ [SYMBOL]: unknown }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "Symbol(key)".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "Symbol(key)".')));
 	});
 
 	it("should narrow the type to an object with the corresponding property (type)", (): void => {
@@ -68,6 +68,6 @@ describe("assertNullishProperty", (): void => {
 			consumeValue<Date & { [SYMBOL]: Nullish<string> }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "Symbol(key)".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "Symbol(key)".')));
 	});
 });

--- a/packages/ts-predicate/test/extended/nullish/predicate/type-assertion/assert-nullish.spec.mts
+++ b/packages/ts-predicate/test/extended/nullish/predicate/type-assertion/assert-nullish.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { type NullishValues, assertNullish } from "../../../../../src/_index.mjs";
+import { type NullishValues, ValidationError, assertNullish } from "../../../../../src/_index.mjs";
 
 describe("assertNullish", (): void => {
 	it("should return when given null, undefined, NaN, or NoValue", (): void => {
@@ -28,7 +28,7 @@ describe("assertNullish", (): void => {
 				assertNullish(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/helper/get-constructor-of.spec.mts
+++ b/packages/ts-predicate/test/helper/get-constructor-of.spec.mts
@@ -16,7 +16,7 @@ describe("getConstructorOf", (): void => {
 			getConstructorOf(Object.create(null));
 		};
 
-		throws(WRAPPER, createErrorTest("The value has no prototype."));
+		throws(WRAPPER, createErrorTest(new Error("The value has no prototype.")));
 	});
 
 	it("should throw when given an object without constructor", (): void => {
@@ -25,7 +25,7 @@ describe("getConstructorOf", (): void => {
 			getConstructorOf(Object.create(Object.create(null)));
 		};
 
-		throws(WRAPPER, createErrorTest("The value has no constructor."));
+		throws(WRAPPER, createErrorTest(new Error("The value has no constructor.")));
 	});
 
 	it("should return a constructor that can be instantiated", (): void => {

--- a/packages/ts-predicate/test/type-assertion/assert-allowed-keys.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-allowed-keys.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
-import { assertAllowedKeys } from "../../src/_index.mjs";
 import { createErrorTest } from "@vitruvius-labs/testing-ground";
+import { ValidationError, assertAllowedKeys } from "../../src/_index.mjs";
 
 describe("assertAllowedKeys", (): void => {
 	it("should return when every key is allowed, even if some allowed keys are missing", (): void => {
@@ -24,7 +24,7 @@ describe("assertAllowedKeys", (): void => {
 			assertAllowedKeys({ alpha: 1, beta: 2, gamma: 3, delta: 4 }, ["alpha", "beta"]);
 		};
 
-		throws(WRAPPER_SINGLE, createErrorTest('The value must not have the properties "gamma".'));
-		throws(WRAPPER_MULTIPLE, createErrorTest('The value must not have the properties "gamma", "delta".'));
+		throws(WRAPPER_SINGLE, createErrorTest(new ValidationError('The value must not have the properties "gamma".')));
+		throws(WRAPPER_MULTIPLE, createErrorTest(new ValidationError('The value must not have the properties "gamma", "delta".')));
 	});
 });

--- a/packages/ts-predicate/test/type-assertion/assert-array.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-array.spec.mts
@@ -67,7 +67,7 @@ describe("assertArray", (): void => {
 			assertArray([], { minLength: 0 });
 		};
 
-		throws(WRAPPER, createErrorTest(new RangeError(
+		throws(WRAPPER, createErrorTest(new ValidationError(
 			"The minimum length cannot be less than one."
 		)));
 	});

--- a/packages/ts-predicate/test/type-assertion/assert-array.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-array.spec.mts
@@ -67,7 +67,7 @@ describe("assertArray", (): void => {
 			assertArray([], { minLength: 0 });
 		};
 
-		throws(WRAPPER, createErrorTest(new ValidationError(
+		throws(WRAPPER, createErrorTest(new RangeError(
 			"The minimum length cannot be less than one."
 		)));
 	});

--- a/packages/ts-predicate/test/type-assertion/assert-big-int.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-big-int.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertBigInt } from "../../src/_index.mjs";
+import { ValidationError, assertBigInt } from "../../src/_index.mjs";
 
 describe("assertBigInt", (): void => {
 	it("should return when given a big integer", (): void => {
@@ -28,7 +28,7 @@ describe("assertBigInt", (): void => {
 				assertBigInt(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-boolean.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-boolean.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertBoolean } from "../../src/_index.mjs";
+import { ValidationError, assertBoolean } from "../../src/_index.mjs";
 
 describe("assertBoolean", (): void => {
 	it("should return when given a boolean", (): void => {
@@ -28,7 +28,7 @@ describe("assertBoolean", (): void => {
 				assertBoolean(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-constructor.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-constructor.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { type AbstractConstructorOf, assertConstructor } from "../../src/_index.mjs";
+import { type AbstractConstructorOf, ValidationError, assertConstructor } from "../../src/_index.mjs";
 
 describe("assertConstructor", (): void => {
 	it("should return when given a constructible", (): void => {
@@ -28,7 +28,7 @@ describe("assertConstructor", (): void => {
 				assertConstructor(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest("The value must be a constructor."));
+			throws(WRAPPER, createErrorTest(new ValidationError("The value must be a constructor.")));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-defined.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-defined.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { NoValue, type NonNullish, assertDefined } from "../../src/_index.mjs";
+import { NoValue, type NonNullish, ValidationError, assertDefined } from "../../src/_index.mjs";
 
 describe("assertDefined", (): void => {
 	it("should throw when given undefined, null, NaN, or NoValue", (): void => {
@@ -16,7 +16,7 @@ describe("assertDefined", (): void => {
 				assertDefined(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-enum-value.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-enum-value.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues } from "@vitruvius-labs/testing-ground";
-import { assertEnumValue } from "../../src/_index.mjs";
+import { ValidationError, assertEnumValue } from "../../src/_index.mjs";
 
 describe("assertEnumValue", (): void => {
 	it("should return when given a valid value", (): void => {
@@ -30,7 +30,7 @@ describe("assertEnumValue", (): void => {
 				assertEnumValue(ITEM, ENUM_VALUES);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -47,8 +47,8 @@ describe("assertEnumValue", (): void => {
 			assertEnumValue("Lorem ipsum", ENUM_VALUES, "DigitEnum");
 		};
 
-		throws(WRAPPER_ANONYMOUS, createErrorTest("The value must be one of the following: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9."));
-		throws(WRAPPER_NAMED, createErrorTest("The value must be a DigitEnum."));
+		throws(WRAPPER_ANONYMOUS, createErrorTest(new ValidationError("The value must be one of the following: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9.")));
+		throws(WRAPPER_NAMED, createErrorTest(new ValidationError("The value must be a DigitEnum.")));
 	});
 
 	it("should narrow the type to the enumerated values (arbitrary values)", (): void => {

--- a/packages/ts-predicate/test/type-assertion/assert-finite-number.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-finite-number.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertFiniteNumber } from "../../src/_index.mjs";
+import { ValidationError, assertFiniteNumber } from "../../src/_index.mjs";
 
 describe("assertFiniteNumber", (): void => {
 	it("should return when given a real number", (): void => {
@@ -28,7 +28,7 @@ describe("assertFiniteNumber", (): void => {
 				assertFiniteNumber(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -42,7 +42,7 @@ describe("assertFiniteNumber", (): void => {
 				assertFiniteNumber(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-instance-of.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-instance-of.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { consumeValue, createErrorTest, createValue, getAllValues } from "@vitruvius-labs/testing-ground";
-import { assertInstanceOf } from "../../src/_index.mjs";
+import { ValidationError, assertInstanceOf } from "../../src/_index.mjs";
 
 describe("assertInstanceOf", (): void => {
 	it("should return when given an instance of the given class", (): void => {
@@ -23,7 +23,7 @@ describe("assertInstanceOf", (): void => {
 				assertInstanceOf(ITEM, Date);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-integer.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-integer.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertInteger } from "../../src/_index.mjs";
+import { ValidationError, assertInteger } from "../../src/_index.mjs";
 
 describe("assertInteger", (): void => {
 	it("should return when given a safe integer", (): void => {
@@ -28,7 +28,7 @@ describe("assertInteger", (): void => {
 				assertInteger(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 
@@ -42,7 +42,7 @@ describe("assertInteger", (): void => {
 				assertInteger(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-nullable-property.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-nullable-property.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { consumeValue, createErrorTest, createValue } from "@vitruvius-labs/testing-ground";
-import { type Nullable, assertNullableProperty, assertString } from "../../src/_index.mjs";
+import { type Nullable, ValidationError, assertNullableProperty, assertString } from "../../src/_index.mjs";
 
 describe("assertNullableProperty", (): void => {
 	it("should throw when given an object without the property", (): void => {
@@ -15,8 +15,8 @@ describe("assertNullableProperty", (): void => {
 			assertNullableProperty({}, SYMBOL);
 		};
 
-		throws(WRAPPER_STRING, createErrorTest("The value must have a property \"key\"."));
-		throws(WRAPPER_SYMBOL, createErrorTest("The value must have a property \"Symbol(key)\"."));
+		throws(WRAPPER_STRING, createErrorTest(new ValidationError("The value must have a property \"key\".")));
+		throws(WRAPPER_SYMBOL, createErrorTest(new ValidationError("The value must have a property \"Symbol(key)\".")));
 	});
 
 	it("should return when given an object with the property", (): void => {
@@ -42,7 +42,7 @@ describe("assertNullableProperty", (): void => {
 			consumeValue<{ key: unknown }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "key".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "key".')));
 	});
 
 	it("should narrow the type to an object with the corresponding property (symbol)", (): void => {
@@ -55,7 +55,7 @@ describe("assertNullableProperty", (): void => {
 			consumeValue<{ [SYMBOL]: unknown }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "Symbol(key)".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "Symbol(key)".')));
 	});
 
 	it("should narrow the type to an object with the corresponding property (type)", (): void => {
@@ -68,6 +68,6 @@ describe("assertNullableProperty", (): void => {
 			consumeValue<Date & { [SYMBOL]: Nullable<string> }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "Symbol(key)".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "Symbol(key)".')));
 	});
 });

--- a/packages/ts-predicate/test/type-assertion/assert-nullable.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-nullable.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues } from "@vitruvius-labs/testing-ground";
-import { NoValue, assertNullable } from "../../src/_index.mjs";
+import { NoValue, ValidationError, assertNullable } from "../../src/_index.mjs";
 
 describe("assertNullable", (): void => {
 	it("should return when given null or undefined", (): void => {
@@ -31,7 +31,7 @@ describe("assertNullable", (): void => {
 				assertNullable(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-number.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-number.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertNumber } from "../../src/_index.mjs";
+import { ValidationError, assertNumber } from "../../src/_index.mjs";
 
 describe("assertNumber", (): void => {
 	it("should return when given a number", (): void => {
@@ -28,7 +28,7 @@ describe("assertNumber", (): void => {
 				assertNumber(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-object.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-object.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertObject } from "../../src/_index.mjs";
+import { ValidationError, assertObject } from "../../src/_index.mjs";
 
 describe("assertObject", (): void => {
 	it("should return when given an object", (): void => {
@@ -28,7 +28,7 @@ describe("assertObject", (): void => {
 				assertObject(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-populated-array.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-populated-array.spec.mts
@@ -35,7 +35,7 @@ describe("assertPopulatedArray", (): void => {
 				assertPopulatedArray(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest("The value is not an array."));
+			throws(WRAPPER, createErrorTest(new ValidationError("The value is not an array.")));
 		}
 	});
 
@@ -69,7 +69,7 @@ describe("assertPopulatedArray", (): void => {
 			assertPopulatedArray([], { minLength: 0 });
 		};
 
-		throws(WRAPPER, createErrorTest(new RangeError("The minimum length cannot be less than one.")));
+		throws(WRAPPER, createErrorTest(new ValidationError("The minimum length cannot be less than one.")));
 	});
 
 	it("should throw when given an array with a length below the minLength constraint", (): void => {

--- a/packages/ts-predicate/test/type-assertion/assert-populated-array.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-populated-array.spec.mts
@@ -69,7 +69,7 @@ describe("assertPopulatedArray", (): void => {
 			assertPopulatedArray([], { minLength: 0 });
 		};
 
-		throws(WRAPPER, createErrorTest(new ValidationError("The minimum length cannot be less than one.")));
+		throws(WRAPPER, createErrorTest(new RangeError("The minimum length cannot be less than one.")));
 	});
 
 	it("should throw when given an array with a length below the minLength constraint", (): void => {

--- a/packages/ts-predicate/test/type-assertion/assert-primitive.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-primitive.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertPrimitive } from "../../src/_index.mjs";
+import { ValidationError, assertPrimitive } from "../../src/_index.mjs";
 
 describe("assertPrimitive", (): void => {
 	it("should return when given a primitive value", (): void => {
@@ -28,7 +28,7 @@ describe("assertPrimitive", (): void => {
 				assertPrimitive(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-property.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-property.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertProperty, assertString } from "../../src/_index.mjs";
+import { ValidationError, assertProperty, assertString } from "../../src/_index.mjs";
 
 describe("assertProperty", (): void => {
 	it("should throw when given an object without the property", (): void => {
@@ -15,8 +15,8 @@ describe("assertProperty", (): void => {
 			assertProperty({}, SYMBOL);
 		};
 
-		throws(WRAPPER_STRING, createErrorTest("The value must have a property \"answer\"."));
-		throws(WRAPPER_SYMBOL, createErrorTest("The value must have a property \"Symbol(answer)\"."));
+		throws(WRAPPER_STRING, createErrorTest(new ValidationError("The value must have a property \"answer\".")));
+		throws(WRAPPER_SYMBOL, createErrorTest(new ValidationError("The value must have a property \"Symbol(answer)\".")));
 	});
 
 	it("should throw when given an object with the property, but the value is nullish", (): void => {
@@ -34,8 +34,8 @@ describe("assertProperty", (): void => {
 				assertProperty({ [SYMBOL]: ITEM }, SYMBOL);
 			};
 
-			throws(WRAPPER_STRING, createErrorTest("The property \"answer\" must not have a nullish value (undefined, null, NaN, or NoValue)."));
-			throws(WRAPPER_SYMBOL, createErrorTest("The property \"Symbol(answer)\" must not have a nullish value (undefined, null, NaN, or NoValue)."));
+			throws(WRAPPER_STRING, createErrorTest(new ValidationError("The property \"answer\" must not have a nullish value (undefined, null, NaN, or NoValue).")));
+			throws(WRAPPER_SYMBOL, createErrorTest(new ValidationError("The property \"Symbol(answer)\" must not have a nullish value (undefined, null, NaN, or NoValue).")));
 		}
 	});
 
@@ -74,8 +74,8 @@ describe("assertProperty", (): void => {
 				assertProperty({ [SYMBOL]: ITEM }, SYMBOL, assertString);
 			};
 
-			throws(WRAPPER_STRING, createErrorTest("The value must be a string."));
-			throws(WRAPPER_SYMBOL, createErrorTest("The value must be a string."));
+			throws(WRAPPER_STRING, createErrorTest(new ValidationError("The value must be a string.")));
+			throws(WRAPPER_SYMBOL, createErrorTest(new ValidationError("The value must be a string.")));
 		}
 	});
 
@@ -107,7 +107,7 @@ describe("assertProperty", (): void => {
 			consumeValue<{ key: unknown }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "key".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "key".')));
 	});
 
 	it("should narrow the type to an object with the corresponding property (symbol)", (): void => {
@@ -120,7 +120,7 @@ describe("assertProperty", (): void => {
 			consumeValue<{ [SYMBOL]: unknown }>(VALUE);
 		};
 
-		throws(WRAPPER, createErrorTest('The value must have a property "Symbol(key)".'));
+		throws(WRAPPER, createErrorTest(new ValidationError('The value must have a property "Symbol(key)".')));
 	});
 
 	it("should narrow the type to an object with the corresponding property (type)", (): void => {

--- a/packages/ts-predicate/test/type-assertion/assert-record.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-record.spec.mts
@@ -28,7 +28,7 @@ describe("assertRecord", (): void => {
 				assertRecord(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest("The value must be a record."));
+			throws(WRAPPER, createErrorTest(new ValidationError("The value must be a record.")));
 		}
 	});
 
@@ -42,7 +42,7 @@ describe("assertRecord", (): void => {
 				assertRecord(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest("The value must be a record."));
+			throws(WRAPPER, createErrorTest(new ValidationError("The value must be a record.")));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-string.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-string.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertString } from "../../src/_index.mjs";
+import { ValidationError, assertString } from "../../src/_index.mjs";
 
 describe("assertString", (): void => {
 	it("should return when given a string", (): void => {
@@ -28,7 +28,7 @@ describe("assertString", (): void => {
 				assertString(ITEM);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-structured-data.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-structured-data.spec.mts
@@ -31,7 +31,7 @@ describe("assertStructuredData", (): void => {
 				assertStructuredData(ITEM, DESCRIPTOR);
 			};
 
-			throws(WRAPPER, createErrorTest("The value must be a record."));
+			throws(WRAPPER, createErrorTest(new ValidationError("The value must be a record.")));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/assert-union.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/assert-union.spec.mts
@@ -1,7 +1,7 @@
 import { doesNotThrow, throws } from "node:assert";
 import { describe, it } from "node:test";
 import { GroupType, consumeValue, createErrorTest, createValue, getInvertedValues, getValues } from "@vitruvius-labs/testing-ground";
-import { assertNumber, assertString, assertUnion } from "../../src/_index.mjs";
+import { ValidationError, assertNumber, assertString, assertUnion } from "../../src/_index.mjs";
 
 describe("assertUnion", (): void => {
 	it("should return when given a value matching one of the test", (): void => {
@@ -28,7 +28,7 @@ describe("assertUnion", (): void => {
 				assertUnion(ITEM, [assertNumber, assertString]);
 			};
 
-			throws(WRAPPER, createErrorTest());
+			throws(WRAPPER, createErrorTest(ValidationError));
 		}
 	});
 

--- a/packages/ts-predicate/test/type-assertion/utils/item-assertion.spec.mts
+++ b/packages/ts-predicate/test/type-assertion/utils/item-assertion.spec.mts
@@ -34,7 +34,7 @@ describe("TypeAssertion / utils / itemAssertion", (): void => {
 			itemAssertion(null, GUARD);
 		};
 
-		throws(WRAPPER, createErrorTest());
+		throws(WRAPPER, createErrorTest(ValidationError));
 	});
 
 	it("should return when given a type assertion and a valid value", (): void => {
@@ -72,6 +72,6 @@ describe("TypeAssertion / utils / itemAssertion", (): void => {
 			itemAssertion(null, GUARD);
 		};
 
-		throws(WRAPPER, createErrorTest());
+		throws(WRAPPER, createErrorTest(ValidationError));
 	});
 });


### PR DESCRIPTION
TS Predicate
- All assertions throw exclusively instances of ValidationError
- Unit tests have been updated to check the class of the error

Testing Ground
- `createErrorTest` accept an error constructor parameter